### PR TITLE
Implement ingestion pipeline (ClinicalTrials.gov helpers + trial classification)

### DIFF
--- a/app/services/ctgov/__init__.py
+++ b/app/services/ctgov/__init__.py
@@ -1,0 +1,4 @@
+from app.services.ctgov.study_detail import get_trial_data
+from app.services.ctgov.study_index import iter_study_index_rows
+
+__all__ = ["iter_study_index_rows", "get_trial_data"]

--- a/app/services/ctgov/__init__.py
+++ b/app/services/ctgov/__init__.py
@@ -1,3 +1,11 @@
+"""
+Public API for the ClinicalTrials.gov service layer.
+
+Re-exports the two primary helpers used throughout the ingestion pipeline:
+  - iter_study_index_rows: paginated index fetch (NCT ID + last-update date)
+  - get_trial_data:        single-study detail fetch and formatted print
+"""
+
 from app.services.ctgov.study_detail import get_trial_data
 from app.services.ctgov.study_index import iter_study_index_rows
 

--- a/app/services/ctgov/study_detail.py
+++ b/app/services/ctgov/study_detail.py
@@ -7,10 +7,8 @@ and formats it into a readable template.
 
 
 def get_trial_data(nct_id):
-    # API v2 endpoint for a single study
     url = f"https://clinicaltrials.gov/api/v2/studies/{nct_id}"
 
-    # Selecting the specific fields needed for your template
     params = {
         "fields": (
             "protocolSection.identificationModule.officialTitle,"
@@ -29,7 +27,6 @@ def get_trial_data(nct_id):
         response.raise_for_status()
         study = response.json()
 
-        # Accessing nested data safely
         protocol = study.get("protocolSection", {})
         ident = protocol.get("identificationModule", {})
         status = protocol.get("statusModule", {})
@@ -40,7 +37,6 @@ def get_trial_data(nct_id):
             "interventions", []
         )
 
-        # Format Eligibility Criteria (Split Inclusion/Exclusion)
         criteria = eligibility.get("eligibilityCriteria", "")
         inclusion = "Not specified"
         exclusion = "Not specified"
@@ -49,7 +45,6 @@ def get_trial_data(nct_id):
             inclusion = parts[0].replace("Inclusion Criteria:", "").strip()
             exclusion = parts[1].strip()
 
-        # Build the Template Output
         print(f"--- {ident.get('officialTitle')} ---")
         print(
             f"Last Update Posted: "

--- a/app/services/ctgov/study_detail.py
+++ b/app/services/ctgov/study_detail.py
@@ -1,14 +1,28 @@
-import requests
+"""
+Fetches and prints clinical trial data from the ClinicalTrials.gov API v2.
 
+Used as a diagnostic/debug helper during ingestion development.
+For bulk index fetching see study_index.iter_study_index_rows.
 """
-This script fetches clinical trial data from ClinicalTrials.gov API v2
-and formats it into a readable template.
-"""
+
+import requests
 
 
 def get_trial_data(nct_id):
+    """
+    Fetch a single study from ClinicalTrials.gov and print a human-readable summary.
+
+    Requests a subset of fields from the API v2 single-study endpoint and
+    prints the title, status, eligibility criteria, interventions, and contact
+    details to stdout.  Intended for local debugging/inspection.
+
+    Args:
+        nct_id: The NCT identifier string (e.g. "NCT04132895").
+    """
+
     url = f"https://clinicaltrials.gov/api/v2/studies/{nct_id}"
 
+    # Request only the fields we display so the response payload stays small
     params = {
         "fields": (
             "protocolSection.identificationModule.officialTitle,"
@@ -37,6 +51,7 @@ def get_trial_data(nct_id):
             "interventions", []
         )
 
+        # Split the combined eligibility text into inclusion and exclusion sections
         criteria = eligibility.get("eligibilityCriteria", "")
         inclusion = "Not specified"
         exclusion = "Not specified"

--- a/app/services/ctgov/study_index.py
+++ b/app/services/ctgov/study_index.py
@@ -8,6 +8,15 @@ API_STUDIES = "https://clinicaltrials.gov/api/v2/studies"
 
 
 def _safe_get(d: Dict, path: Tuple[str, ...], default=None):
+    """
+    Traverse a nested dict by a sequence of keys, returning *default* if any
+    key is missing or the value at that level is not a dict.
+
+    Args:
+        d:       The dict to traverse.
+        path:    A tuple of keys forming the access path (e.g. ("a", "b", "c")).
+        default: Value returned when the path cannot be followed.
+    """
     cur = d
     for key in path:
         if not isinstance(cur, dict) or key not in cur:
@@ -98,6 +107,20 @@ def export_index_csv(
     page_size: int = 100,
     sleep_seconds: float = 0.0,
 ) -> None:
+    """
+    Write all matching study index rows to a CSV file.
+
+    Iterates iter_study_index_rows with the provided parameters and writes
+    one row per study to *out_csv_path* with columns [nct_id, last_update_posted_date].
+    Intended as a CLI utility / one-off data export.
+
+    Args:
+        out_csv_path:  Path to the output CSV file (created or overwritten).
+        search_term:   Search text forwarded to iter_study_index_rows.
+        query_mode:    Query mode forwarded to iter_study_index_rows.
+        page_size:     API page size forwarded to iter_study_index_rows.
+        sleep_seconds: Delay between API pages forwarded to iter_study_index_rows.
+    """
     with (
         requests.Session() as s,
         open(out_csv_path, "w", newline="", encoding="utf-8") as f,

--- a/app/services/ctgov/study_index.py
+++ b/app/services/ctgov/study_index.py
@@ -7,7 +7,6 @@ import requests
 API_STUDIES = "https://clinicaltrials.gov/api/v2/studies"
 
 
-# Helper to safely access nested dicts
 def _safe_get(d: Dict, path: Tuple[str, ...], default=None):
     cur = d
     for key in path:
@@ -21,7 +20,7 @@ def iter_study_index_rows(
     search_term: str = "osteosarcoma",
     query_mode: str = "term",
     page_size: int = 100,
-    sleep_seconds: float = 0.0,  # small delay between requests to avoid rate limiting
+    sleep_seconds: float = 0.0,
     session: Optional[requests.Session] = None,
 ) -> Iterator[Tuple[str, str]]:
     """
@@ -48,7 +47,6 @@ def iter_study_index_rows(
     s = session or requests.Session()
     page_token: Optional[str] = None
 
-    # Limit payload to the exact fields you need
     fields = ",".join(
         [
             "protocolSection.identificationModule.nctId",

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -8,9 +8,9 @@ It syncs our database with ClinicalTrials.gov for a list of search terms.
 
 EXISTING CODE USED
 ==================
-- scripts.ctg_study_index.iter_study_index_rows(search_term, ...)
+- app.services.ctgov.study_index.iter_study_index_rows(search_term, ...)
     → yields (nct_id, last_update_posted_date) for every study matching a term.
-- scripts.ctg_study_detail.get_trial_data(nct_id)
+- app.services.ctgov.study_detail.get_trial_data(nct_id)
     → fetches full study JSON from ClinicalTrials.gov API v2.
 
 DATABASE TABLES (see app.db.models)
@@ -59,7 +59,10 @@ AI SERVICES (to be implemented by another developer)
     Returns False → store in IrrelevantTrial with a reason.
 """
 
+import asyncio
 from typing import List
+
+from app.services.ctgov import iter_study_index_rows
 
 
 async def run_daily_ingestion(
@@ -70,17 +73,15 @@ async def run_daily_ingestion(
 
     # ──────────────────────────────────────────────────────────
     # STEP 1 — Collect NCT IDs + last-update dates for each term
-    # Uses: scripts.ctg_study_index.iter_study_index_rows (already implemented)
     # ──────────────────────────────────────────────────────────
-    #
-    #   all_candidates = {}                 # nct_id → last_update_posted_date
-    #
-    #   for term in search_terms:
-    #       for nct_id, last_update in iter_study_index_rows(search_term=term):
-    #           all_candidates[nct_id] = last_update
-    #
-    #   → Result: a dict of every NCT ID that ClinicalTrials.gov returned
-    #     for our search terms, together with the date it was last updated.
+    all_candidates: dict[str, str] = {}
+
+    for term in search_terms:
+        rows = await asyncio.to_thread(
+            lambda t=term: list(iter_study_index_rows(search_term=t))
+        )
+        for nct_id, last_update in rows:
+            all_candidates[nct_id] = last_update
 
     # ──────────────────────────────────────────────────────────
     # STEP 2 — Classify each NCT ID against our database
@@ -113,7 +114,7 @@ async def run_daily_ingestion(
     # ──────────────────────────────────────────────────────────
     # STEP 3 — Fetch full study data for trials that need processing
     # Uses: ClinicalTrials.gov API v2  GET /api/v2/studies/{nct_id}
-    # (see scripts.ctg_study_detail for reference implementation)
+    # (see app.services.ctgov.study_detail for reference implementation)
     # ──────────────────────────────────────────────────────────
     #
     #   trials_to_process = new_trials + updated_trials
@@ -210,3 +211,7 @@ async def run_daily_ingestion(
         "pipeline or disable the scheduled job and related endpoints before "
         "enabling this in production."
     )
+
+
+if __name__ == "__main__":
+    asyncio.run(run_daily_ingestion())

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -111,7 +111,8 @@ async def run_daily_ingestion(
 
     for nct_id, api_date in all_candidates.items():
         if nct_id in existing_map:
-            if existing_map[nct_id] != api_date:
+            db_date = existing_map[nct_id] or ""
+            if db_date != api_date:
                 updated_trials.append(nct_id)
             continue
 

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -62,6 +62,10 @@ AI SERVICES (to be implemented by another developer)
 import asyncio
 from typing import List
 
+from sqlalchemy import select
+
+from app.db.database import SessionLocal
+from app.db.models import ClinicalTrial, IrrelevantTrial
 from app.services.ctgov import iter_study_index_rows
 
 
@@ -85,31 +89,37 @@ async def run_daily_ingestion(
 
     # ──────────────────────────────────────────────────────────
     # STEP 2 — Classify each NCT ID against our database
-    # Three groups:
     # ──────────────────────────────────────────────────────────
-    #
-    #   new_trials     = []    # NCT not in either table         → must fetch & process
-    #   updated_trials = []    # NCT in ClinicalTrial but date changed → must re-fetch
-    #   rejected_hits  = []    # NCT in IrrelevantTrial          → check date (TBD policy)
-    #
-    #   for nct_id, api_date in all_candidates.items():
-    #
-    #       existing = db.query(ClinicalTrial).get(nct_id)
-    #       if existing:
-    #           if existing.last_update_post_date != api_date:
-    #               updated_trials.append(nct_id)
-    #           # else: unchanged → skip, nothing to do
-    #           continue
-    #
-    #       rejected = db.query(IrrelevantTrial).get(nct_id)
-    #       if rejected:
-    #           rejected_hits.append((nct_id, api_date, rejected.last_update_post_date))
-    #           # TBD: policy for whether to re-evaluate rejected trials
-    #           #   - if date changed → maybe re-fetch and re-classify
-    #           #   - if date unchanged → skip
-    #           continue
-    #
-    #       new_trials.append(nct_id)
+    new_trials: list[str] = []
+    updated_trials: list[str] = []
+    rejected_hits: list[tuple[str, str, str | None]] = []
+
+    candidate_ids = list(all_candidates.keys())
+
+    async with SessionLocal() as db:
+        result = await db.execute(
+            select(ClinicalTrial.nct_id, ClinicalTrial.last_update_post_date)
+            .where(ClinicalTrial.nct_id.in_(candidate_ids))
+        )
+        existing_map = {row.nct_id: row.last_update_post_date for row in result}
+
+        result = await db.execute(
+            select(IrrelevantTrial.nct_id, IrrelevantTrial.last_update_post_date)
+            .where(IrrelevantTrial.nct_id.in_(candidate_ids))
+        )
+        rejected_map = {row.nct_id: row.last_update_post_date for row in result}
+
+    for nct_id, api_date in all_candidates.items():
+        if nct_id in existing_map:
+            if existing_map[nct_id] != api_date:
+                updated_trials.append(nct_id)
+            continue
+
+        if nct_id in rejected_map:
+            rejected_hits.append((nct_id, api_date, rejected_map[nct_id]))
+            continue
+
+        new_trials.append(nct_id)
 
     # ──────────────────────────────────────────────────────────
     # STEP 3 — Fetch full study data for trials that need processing

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -78,17 +78,26 @@ async def run_daily_ingestion(
     # ──────────────────────────────────────────────────────────
     # STEP 1 — Collect NCT IDs + last-update dates for each term
     # ──────────────────────────────────────────────────────────
+    # nct_id → last_update_posted_date (ISO 8601 string or "" if unknown)
     all_candidates: dict[str, str] = {}
 
     for term in search_terms:
+        # iter_study_index_rows is a blocking generator; run it in a thread
+        # pool so it does not block the async event loop.
         rows = await asyncio.to_thread(
             lambda t=term: list(iter_study_index_rows(search_term=t))
         )
         for nct_id, last_update in rows:
+            # Later search terms overwrite earlier ones for the same NCT ID;
+            # the date is the same regardless of which term matched.
             all_candidates[nct_id] = last_update
 
     # ──────────────────────────────────────────────────────────
     # STEP 2 — Classify each NCT ID against our database
+    # Three possible outcomes per candidate:
+    #   new_trials     – NCT not in either table → fetch & process
+    #   updated_trials – NCT in ClinicalTrial but date changed → re-fetch
+    #   rejected_hits  – NCT in IrrelevantTrial → policy TBD (step 6)
     # ──────────────────────────────────────────────────────────
     new_trials: list[str] = []
     updated_trials: list[str] = []
@@ -97,26 +106,34 @@ async def run_daily_ingestion(
     candidate_ids = list(all_candidates.keys())
 
     async with SessionLocal() as db:
+        # Fetch last-update dates for every candidate already in ClinicalTrial
         result = await db.execute(
             select(ClinicalTrial.nct_id, ClinicalTrial.last_update_post_date)
             .where(ClinicalTrial.nct_id.in_(candidate_ids))
         )
+        # Map: nct_id → stored last_update_post_date (may be None if not recorded)
         existing_map = {row.nct_id: row.last_update_post_date for row in result}
 
+        # Fetch last-update dates for every candidate already in IrrelevantTrial
         result = await db.execute(
             select(IrrelevantTrial.nct_id, IrrelevantTrial.last_update_post_date)
             .where(IrrelevantTrial.nct_id.in_(candidate_ids))
         )
+        # Map: nct_id → stored last_update_post_date (may be None if not recorded)
         rejected_map = {row.nct_id: row.last_update_post_date for row in result}
 
     for nct_id, api_date in all_candidates.items():
         if nct_id in existing_map:
+            # Coerce None → "" so that a missing DB date does not falsely
+            # trigger an update when the API also returns no date.
             db_date = existing_map[nct_id] or ""
             if db_date != api_date:
                 updated_trials.append(nct_id)
             continue
 
         if nct_id in rejected_map:
+            # Keep the stored date alongside the API date so step 6 can
+            # decide whether to re-evaluate (date changed) or skip.
             rejected_hits.append((nct_id, api_date, rejected_map[nct_id]))
             continue
 


### PR DESCRIPTION
# Pull Request

## Description

Refactors and extends the ClinicalTrials.gov ingestion scaffolding by wiring the ingestion service to the `app.services.ctgov` helpers and partially implementing the daily ingestion pipeline.

Key changes:
- Introduces the `app.services.ctgov` package that exposes ClinicalTrials.gov helpers (`iter_study_index_rows`, `get_trial_data`) for reuse across the application.
- Partially implements ingestion steps 1–2 in `run_daily_ingestion`: fetches candidate NCT IDs and last-update dates from the CT.gov index (via `asyncio.to_thread`), then classifies them against `ClinicalTrial`/`IrrelevantTrial` using SQLAlchemy `select` queries, producing `new_trials`, `updated_trials`, and `rejected_hits` lists. Later pipeline steps remain unimplemented.
- Updates ingestion documentation references from the old `scripts.*` paths to the new `app.services.ctgov.*` paths.
- Fixes a bug in trial update detection: `existing_map[nct_id]` (DB value, nullable `None`) is now coerced to `""` before comparing with `api_date` (already normalized to `""` by `iter_study_index_rows`), preventing `None != ""` from incorrectly marking trials as updated when both sides effectively mean "unknown date".
- Adds docstrings and inline comments throughout all changed files: module docstring for `ctgov/__init__.py`; fixed misplaced module docstring, new function docstring, and inline comments in `study_detail.py`; docstrings for `_safe_get` and `export_index_csv` in `study_index.py`; and inline comments on the implemented steps 1 and 2 in `ingestion.py` explaining thread-pool usage, dict semantics, and the `None → ""` coercion.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Existing unit tests were run to verify no regressions were introduced. All 2 tests pass.

```
pytest tests/
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes