### PR TITLE
Phase 1.7: add GET /api/v1/trail endpoint for WordPress PHP template

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -43,6 +43,94 @@ async def get_trials(
     return trials
 
 
+class PhpTrialResult(BaseModel):
+    NCTId: str
+    BriefTitle: Optional[str] = None
+    CustomBriefTitle: Optional[str] = None
+    BriefSummary: Optional[str] = None
+    CustomBriefSummary: Optional[str] = None
+    OverallStatus: Optional[str] = None
+    CustomOverallStatus: Optional[str] = None
+    Phase: Optional[str] = None
+    CustomPhase: Optional[str] = None
+    StudyType: Optional[str] = None
+    CustomStudyType: Optional[str] = None
+    LocationCountry: Optional[str] = None
+    CustomLocationCountry: Optional[str] = None
+    LocationCity: Optional[str] = None
+    CustomLocationCity: Optional[str] = None
+    MinimumAge: Optional[str] = None
+    CustomMinimumAge: Optional[str] = None
+    MaximumAge: Optional[str] = None
+    CustomMaximumAge: Optional[str] = None
+    CentralContactName: Optional[str] = None
+    CustomCentralContactName: Optional[str] = None
+    CentralContactPhone: Optional[str] = None
+    CustomCentralContactPhone: Optional[str] = None
+    CentralContactEMail: Optional[str] = None
+    CustomCentralContactEMail: Optional[str] = None
+    EligibilityCriteria: Optional[str] = None
+    CustomEligibilityCriteria: Optional[str] = None
+    InterventionDescription: Optional[str] = None
+    CustomInterventionDescription: Optional[str] = None
+    LastUpdatePostDate: Optional[str] = None
+    CustomLastUpdatePostDate: Optional[str] = None
+    key_information: Optional[str] = None
+
+
+class PhpTrialResponse(BaseModel):
+    result: List[PhpTrialResult]
+
+
+@router.get("/trail", response_model=PhpTrialResponse)
+async def get_trail(trail_id: str, db: AsyncSession = Depends(get_db)):
+    """WordPress PHP template endpoint — returns an approved trial in legacy PascalCase format."""
+    stmt = select(ClinicalTrial).where(
+        ClinicalTrial.nct_id == trail_id,
+        ClinicalTrial.status == TrialStatus.APPROVED,
+    )
+    result = await db.execute(stmt)
+    trial = result.scalars().first()
+
+    if not trial:
+        raise HTTPException(status_code=404, detail="Trial not found")
+
+    return PhpTrialResponse(result=[PhpTrialResult(
+        NCTId=trial.nct_id,
+        BriefTitle=trial.brief_title,
+        CustomBriefTitle=trial.custom_brief_title,
+        BriefSummary=trial.brief_summary,
+        CustomBriefSummary=trial.custom_brief_summary,
+        OverallStatus=trial.overall_status,
+        CustomOverallStatus=trial.custom_overall_status,
+        Phase=trial.phase,
+        CustomPhase=trial.custom_phase,
+        StudyType=trial.study_type,
+        CustomStudyType=trial.custom_study_type,
+        LocationCountry=trial.location_country,
+        CustomLocationCountry=trial.custom_location_country,
+        LocationCity=trial.location_city,
+        CustomLocationCity=trial.custom_location_city,
+        MinimumAge=trial.minimum_age,
+        CustomMinimumAge=trial.custom_minimum_age,
+        MaximumAge=trial.maximum_age,
+        CustomMaximumAge=trial.custom_maximum_age,
+        CentralContactName=trial.central_contact_name,
+        CustomCentralContactName=trial.custom_central_contact_name,
+        CentralContactPhone=trial.central_contact_phone,
+        CustomCentralContactPhone=trial.custom_central_contact_phone,
+        CentralContactEMail=trial.central_contact_email,
+        CustomCentralContactEMail=trial.custom_central_contact_email,
+        EligibilityCriteria=trial.eligibility_criteria,
+        CustomEligibilityCriteria=trial.custom_eligibility_criteria,
+        InterventionDescription=trial.intervention_description,
+        CustomInterventionDescription=trial.custom_intervention_description,
+        LastUpdatePostDate=trial.last_update_post_date,
+        CustomLastUpdatePostDate=trial.custom_last_update_post_date,
+        key_information=trial.key_information,
+    )])
+
+
 @router.patch("/trials/{nct_id}", response_model=TrialResponse)
 async def update_trial(
     nct_id: str, body: TrialUpdate, db: AsyncSession = Depends(get_db)

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -1,0 +1,197 @@
+# Ingestion Pipeline
+
+The ingestion pipeline discovers osteosarcoma-related clinical trials on ClinicalTrials.gov, generates patient-friendly AI summaries, classifies relevance, and queues trials for human review before publication.
+
+---
+
+## Triggers
+
+| Method | Detail |
+|--------|--------|
+| **Scheduled** | APScheduler interval job, every `INGESTION_SCHEDULE_HOURS` hours (default: 24). Registered at app startup in `app/main.py`. |
+| **Manual** | `POST /api/v1/debug/run-ingestion` — for testing or on-demand runs. |
+
+---
+
+## Pipeline Overview
+
+```mermaid
+flowchart TD
+    A([Trigger]) --> B[1. Fetch NCT index\nClinicalTrials.gov API]
+    B --> C[2. Classify candidates\nagainst DB]
+    C --> D{Trial status?}
+
+    D -->|New| E[3. Fetch full study data]
+    D -->|Updated date| E
+    D -->|Irrelevant, date changed| E
+    D -->|Irrelevant, same date| Z([Skip])
+
+    E --> F[3.5 Preserve admin edits\nfor existing trials]
+    F --> G[4. AI summarise\ncustom_brief_summary]
+    G --> H[5. AI classify\nrelevance & tier]
+    H --> I{Relevant?}
+
+    I -->|Yes| J[6a. Upsert → clinical_trials\nstatus: PENDING_REVIEW]
+    I -->|No| K[6b. Upsert → irrelevant_trials]
+
+    J --> L[7. Write IngestionRun\naudit row]
+    K --> L
+```
+
+---
+
+## Step-by-Step Breakdown
+
+### Step 1 — Fetch NCT index
+
+**File:** [app/services/ctgov/study_index.py](../app/services/ctgov/study_index.py)
+
+Paginates the ClinicalTrials.gov v2 API using `SEARCH_TERMS` (default: `["osteosarcoma"]`). Collects `nct_id` and `last_update_posted_date` for every matching trial. Returns a dict `{nct_id: date}`.
+
+- Endpoint: `GET https://clinicaltrials.gov/api/v2/studies`
+- Page size: `PAGE_SIZE` (default: 100)
+- No auth required
+
+---
+
+### Step 2 — Classify candidates
+
+**File:** [app/services/ingestion.py](../app/services/ingestion.py)
+
+Compares the index against the database to bucket each NCT ID:
+
+| Bucket | Condition |
+|--------|-----------|
+| `new_trials` | Not in `clinical_trials` or `irrelevant_trials` |
+| `updated_trials` | In `clinical_trials`, but `last_update_post_date` changed |
+| `reeval_trials` | In `irrelevant_trials`, but `last_update_post_date` changed |
+| skipped | In `irrelevant_trials`, date unchanged |
+
+Only trials in the first three buckets proceed to Step 3.
+
+---
+
+### Step 3 — Fetch full study data
+
+**File:** [app/services/ctgov/study_detail.py](../app/services/ctgov/study_detail.py)
+
+Fetches the complete study record for each candidate and maps it to a flat dict matching the `ClinicalTrialBase` schema. Key fields extracted: title, summary, status, phase, eligibility, interventions, locations, contacts.
+
+- Endpoint: `GET https://clinicaltrials.gov/api/v2/studies/{nct_id}`
+- Timeout: 30 s
+- Failures: logged, trial skipped (`fetch_errors++`)
+
+---
+
+### Step 3.5 — Preserve admin edits
+
+**File:** [app/services/ingestion.py](../app/services/ingestion.py)
+
+For trials already in the database (updated or re-evaluated), loads any non-null `custom_*` fields that an admin has manually edited. These values are re-applied after Steps 4–5 so AI output never overwrites human curation.
+
+---
+
+### Step 4 — AI summarise
+
+**File:** [app/services/ai/summarizer.py](../app/services/ai/summarizer.py)
+
+Calls OpenAI to generate `custom_brief_summary` — a 2–3 sentence plain-language description at an 8th-grade reading level.
+
+- Model: `AI_MODEL` (default: `gpt-4o-mini`)
+- Temperature: 0.3
+- Retries: 2 (3 attempts total)
+- Failure: field left `None`; pipeline continues
+
+---
+
+### Step 5 — AI classify
+
+**File:** [app/services/ai/classifier.py](../app/services/ai/classifier.py)
+
+Classifies whether the trial is relevant to osteosarcoma patients and assigns a tier:
+
+| Tier | Meaning |
+|------|---------|
+| `primary` | Osteosarcoma explicitly named |
+| `secondary` | Broader trial (bone sarcoma, solid tumor, pediatric) where osteosarcoma patients are eligible |
+| `irrelevant` | No osteosarcoma connection |
+
+**Fail-safe:** if confidence < `CONFIDENCE_THRESHOLD` (default: 0.7) and the model says irrelevant, the trial is forced to `secondary` with reason "Low confidence — included for human review". Missing a relevant trial is worse than a false positive.
+
+- Temperature: 0.1
+- Retries: 2
+- Exception: defaults to `is_relevant=True, confidence=0.0`
+
+---
+
+### Step 6 — Database upsert
+
+**File:** [app/services/ingestion.py](../app/services/ingestion.py)
+
+| Outcome | Action |
+|---------|--------|
+| Relevant | `session.merge()` into `clinical_trials` with `status=PENDING_REVIEW`. If trial was in `irrelevant_trials`, that row is deleted. |
+| Irrelevant | `session.merge()` into `irrelevant_trials`. If trial was in `clinical_trials`, that row is deleted. |
+| Previously approved | Approval preserved as `previous_approved_at` / `previous_approved_by`; status reset to `PENDING_REVIEW` for re-review. |
+
+---
+
+### Step 7 — Log ingestion run
+
+**File:** [app/services/ingestion.py](../app/services/ingestion.py)
+
+Writes one row to `ingestion_runs` with counts for every outcome and error, plus the search terms used. Provides a full audit trail of every pipeline execution.
+
+---
+
+## Trial Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING_REVIEW: Ingested (new or updated)
+
+    PENDING_REVIEW --> APPROVED: Admin approves
+    PENDING_REVIEW --> REJECTED: Admin rejects
+
+    APPROVED --> PENDING_REVIEW: Re-ingested\n(date changed)
+    REJECTED --> PENDING_REVIEW: Re-ingested\n(date changed)
+
+    APPROVED --> [*]: Published to users\nvia GET /api/v1/trail
+```
+
+---
+
+## Database Tables
+
+| Table | Purpose |
+|-------|---------|
+| `clinical_trials` | Relevant trials awaiting or past human review |
+| `irrelevant_trials` | Trials classified irrelevant; kept for deduplication |
+| `ingestion_runs` | Audit log — one row per pipeline execution |
+
+Schema: [app/db/models.py](../app/db/models.py)
+
+---
+
+## Error Handling
+
+| Step | Failure | Behaviour |
+|------|---------|-----------|
+| 1 — Fetch index | API/network error | Ingestion aborted |
+| 3 — Fetch study | HTTP error or timeout | Trial skipped; `fetch_errors++` |
+| 4 — AI summarise | LLM error after retries | `custom_brief_summary = None`; pipeline continues |
+| 5 — AI classify | LLM error after retries | Defaults to `is_relevant=True`, `confidence=0.0`; logged as `classify_errors` |
+| 6 — DB upsert | SQL error | Exception propagates; run aborted |
+
+---
+
+## Configuration
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `SEARCH_TERMS` | `["osteosarcoma"]` | JSON list of CT.gov search terms |
+| `INGESTION_SCHEDULE_HOURS` | `24` | How often the scheduler fires |
+| `AI_MODEL` | `gpt-4o-mini` | OpenAI model for summarisation and classification |
+| `CONFIDENCE_THRESHOLD` | `0.7` | Min confidence below which irrelevant → forced secondary |
+| `PAGE_SIZE` | `100` | Results per CT.gov API page |
+| `OPENAI_API_KEY` | — | Required; app fails to start if missing |

--- a/roadmap.md
+++ b/roadmap.md
@@ -35,7 +35,6 @@ The project has solid infrastructure in place, but the core ingestion pipeline i
 ### Not done (blocking)
 - Authentication and user management
 - Full trial detail API endpoint (`GET /api/v1/trials/{nct_id}`)
-- PHP template endpoint (`GET /api/v1/trail?trail_id={nct_id}`) — Phase 1.7
 - Admin review queue (new/updated trials)
 - Reviewer notes and audit log
 - Search and filtering in both API and frontend
@@ -45,7 +44,7 @@ The project has solid infrastructure in place, but the core ingestion pipeline i
 
 ## Phases
 
-### Phase 1 — Complete the ingestion pipeline ✅ (1.1–1.6 done)
+### Phase 1 — Complete the ingestion pipeline ✅
 
 This is the critical path. Nothing else matters until data flows end-to-end.
 
@@ -100,13 +99,13 @@ Create a new function `ai_generate_summaries(client, trial_data: dict) -> dict` 
 - `ingestion_runs` table added (migration 003): one row per run with all counts — queryable audit trail
 - Per-trial error handling: one bad trial does not abort the run; `fetch_errors` and `classify_errors` are tracked and written to `ingestion_runs`
 
-#### 1.7 Fix the PHP template API endpoint
+#### 1.7 Fix the PHP template API endpoint ✅
 
-The WordPress template `template-single-study.php` calls `/api/get-trail?trail_id={nct_id}` which does not exist in the codebase. Add this endpoint:
-
-- `GET /api/v1/trail?trail_id={nct_id}` (or update the PHP template to call the correct path)
-- Returns full trial data — all `custom_*` fields preferred, falling back to `official_*` fields if custom is null
-- This is the endpoint consumed by the live Osteosarcoma Now website
+- Added `GET /api/v1/trail?trail_id={nct_id}` to FastAPI (`app/api/endpoints.py`)
+- Returns full trial data in PascalCase JSON (`{ "result": [...] }`) matching what the PHP template expects
+- Only returns `APPROVED` trials; returns 404 for missing or non-approved trials
+- Updated `templates/template-single-study.php` to call the new path; host is read from the `ONTEX_API_BASE` WordPress constant (set in `wp-config.php`) instead of hardcoded
+- 3 tests added to `tests/test_api.py` covering 404-missing, 404-non-approved, and 200-approved cases
 
 ---
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -102,7 +102,7 @@ Create a new function `ai_generate_summaries(client, trial_data: dict) -> dict` 
 #### 1.7 Fix the PHP template API endpoint ✅
 
 - Added `GET /api/v1/trail?trail_id={nct_id}` to FastAPI (`app/api/endpoints.py`)
-- Returns full trial data in PascalCase JSON (`{ "result": [...] }`) matching what the PHP template expects
+- Returns full trial data in PascalCase JSON (`{ "result": [...] }`) matching what the PHP template expects — all fields are PascalCase except `key_information` which is snake_case (the PHP template reads it as `$customresult->key_information`)
 - Only returns `APPROVED` trials; returns 404 for missing or non-approved trials
 - Updated `templates/template-single-study.php` to call the new path; host is read from the `ONTEX_API_BASE` WordPress constant (set in `wp-config.php`) instead of hardcoded
 - 3 tests added to `tests/test_api.py` covering 404-missing, 404-non-approved, and 200-approved cases

--- a/templates/template-single-study.php
+++ b/templates/template-single-study.php
@@ -5,7 +5,8 @@ if(isset($_REQUEST['id']) && $_REQUEST['id'] != ""){
 	//$search_query .= " AND AREA[NCTId]$nctid";
 	$search_query = "AREA[NCTId]$nctid";
 } 
-$urll = str_replace(" ","+","http://jayr57.sg-host.com/api/get-trail?trail_id=$nctid");
+$api_base = defined('ONTEX_API_BASE') ? ONTEX_API_BASE : 'https://<YOUR-RAILWAY-URL>';
+$urll = str_replace(" ","+","$api_base/api/v1/trail?trail_id=$nctid");
  // echo $urll;
 $curll = curl_init();
 curl_setopt_array($curll, array(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,16 @@
 """
 Pytest configuration and fixtures for test suite.
-Handles proper cleanup of resources like database connections and event loops.
 """
 
 import asyncio
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 # Ensure repository root is on sys.path so `import app` works in CI
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -16,32 +18,49 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 @pytest.fixture(scope="session", autouse=True)
 def event_loop():
-    """
-    Create a single event loop for the entire test session.
-    This prevents event loop issues and ensures proper cleanup.
-    """
+    """Single event loop for the entire test session."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     yield loop
     loop.close()
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def cleanup_engines():
+@pytest_asyncio.fixture
+async def db_engine(tmp_path):
+    """A fresh SQLite engine with all tables created, scoped to one test."""
+    from app.db.database import Base
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/test.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def test_client(db_engine, monkeypatch):
     """
-    Fixture that automatically runs after each test to ensure
-    all SQLAlchemy engines are properly disposed.
+    AsyncClient wired to a fresh per-test SQLite DB via get_db dependency override.
 
-    This prevents the Python process from hanging due to unclosed
-    database connections waiting for cleanup.
+    Ingestion is patched to a no-op so tests don't hit the external API.
+    Individual tests may re-patch run_daily_ingestion after receiving this fixture
+    if they need to inspect calls (monkeypatch.setattr overwrites the noop).
     """
-    yield
+    import app.services.ingestion as ingestion
 
-    # After test completes, dispose all engines
-    # Import here to avoid issues if test hasn't imported the db module
-    try:
-        from app.db.database import engine
+    monkeypatch.setattr(ingestion, "run_daily_ingestion", AsyncMock(return_value=None))
+    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
 
-        await engine.dispose()
-    except Exception as e:
-        print(f"Warning: Error disposing engine in cleanup: {e}")
+    from app.db.database import get_db
+    from app.main import app
+
+    async def override_get_db():
+        async with AsyncSession(db_engine) as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        yield client
+
+    app.dependency_overrides.clear()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,94 +1,24 @@
-import pathlib
-import sys
-
 import pytest
 
-# Ensure repository root is on sys.path so `import app` works in CI
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-
-from httpx import AsyncClient
+from app.db.models import ClinicalTrial, TrialStatus
 
 
 @pytest.mark.asyncio
-async def test_get_trials_returns_list(tmp_path, monkeypatch):
-    db_file = tmp_path / "test.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
-    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
-
-    # Patch ingestion function to a no-op before importing the app
-    import app.services.ingestion as ingestion
-
-    async def noop():
-        return None
-
-    monkeypatch.setattr(ingestion, "run_daily_ingestion", noop)
-
-    # Import app after env is configured
-    from app.db.database import Base, engine
-    from app.main import app, scheduler
-
-    # Ensure tables exist for the sqlite test DB
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        r = await ac.get("/api/v1/trials")
-        assert r.status_code == 200
-        assert isinstance(r.json(), list)
-
-    # Shutdown scheduler if it's running
-    if scheduler.running:
-        scheduler.shutdown()
+async def test_get_trials_returns_list(test_client):
+    r = await test_client.get("/api/v1/trials")
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
 
 
 @pytest.mark.asyncio
-async def test_get_trail_returns_404_for_missing(tmp_path, monkeypatch):
-    db_file = tmp_path / "test3.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
-    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
-
-    import app.services.ingestion as ingestion
-
-    async def noop():
-        return None
-
-    monkeypatch.setattr(ingestion, "run_daily_ingestion", noop)
-
-    from app.db.database import Base, engine
-    from app.main import app, scheduler
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        r = await ac.get("/api/v1/trail?trail_id=NCT_MISSING")
-        assert r.status_code == 404
-
-    if scheduler.running:
-        scheduler.shutdown()
+async def test_get_trail_returns_404_for_missing(test_client):
+    r = await test_client.get("/api/v1/trail?trail_id=NCT_MISSING")
+    assert r.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_get_trail_returns_404_for_non_approved(tmp_path, monkeypatch):
-    db_file = tmp_path / "test4.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
-    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
-
-    import app.services.ingestion as ingestion
-
-    async def noop():
-        return None
-
-    monkeypatch.setattr(ingestion, "run_daily_ingestion", noop)
-
-    from app.db.database import Base, engine
-    from app.db.models import ClinicalTrial, TrialStatus
-    from app.main import app, scheduler
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    async with engine.begin() as conn:
+async def test_get_trail_returns_404_for_non_approved(test_client, db_engine):
+    async with db_engine.begin() as conn:
         await conn.execute(
             ClinicalTrial.__table__.insert().values(
                 nct_id="NCT00000001",
@@ -97,35 +27,13 @@ async def test_get_trail_returns_404_for_non_approved(tmp_path, monkeypatch):
             )
         )
 
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        r = await ac.get("/api/v1/trail?trail_id=NCT00000001")
-        assert r.status_code == 404
-
-    if scheduler.running:
-        scheduler.shutdown()
+    r = await test_client.get("/api/v1/trail?trail_id=NCT00000001")
+    assert r.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_get_trail_returns_approved_trial(tmp_path, monkeypatch):
-    db_file = tmp_path / "test5.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
-    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
-
-    import app.services.ingestion as ingestion
-
-    async def noop():
-        return None
-
-    monkeypatch.setattr(ingestion, "run_daily_ingestion", noop)
-
-    from app.db.database import Base, engine
-    from app.db.models import ClinicalTrial, TrialStatus
-    from app.main import app, scheduler
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    async with engine.begin() as conn:
+async def test_get_trail_returns_approved_trial(test_client, db_engine):
+    async with db_engine.begin() as conn:
         await conn.execute(
             ClinicalTrial.__table__.insert().values(
                 nct_id="NCT00000002",
@@ -138,50 +46,30 @@ async def test_get_trail_returns_approved_trial(tmp_path, monkeypatch):
             )
         )
 
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        r = await ac.get("/api/v1/trail?trail_id=NCT00000002")
-        assert r.status_code == 200
-        body = r.json()
-        assert "result" in body
-        trial = body["result"][0]
-        assert trial["NCTId"] == "NCT00000002"
-        assert trial["BriefTitle"] == "Approved Osteosarcoma Trial"
-        assert trial["CustomBriefSummary"] == "Patient-friendly summary."
-        assert trial["key_information"] == "Key facts here."
-        assert trial["CentralContactEMail"] == "contact@example.com"
-
-    if scheduler.running:
-        scheduler.shutdown()
+    r = await test_client.get("/api/v1/trail?trail_id=NCT00000002")
+    assert r.status_code == 200
+    body = r.json()
+    assert "result" in body
+    trial = body["result"][0]
+    assert trial["NCTId"] == "NCT00000002"
+    assert trial["BriefTitle"] == "Approved Osteosarcoma Trial"
+    assert trial["CustomBriefSummary"] == "Patient-friendly summary."
+    assert trial["key_information"] == "Key facts here."
+    assert trial["CentralContactEMail"] == "contact@example.com"
 
 
 @pytest.mark.asyncio
-async def test_debug_ingestion_endpoint(monkeypatch, tmp_path):
-    db_file = tmp_path / "test2.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
-    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
-
-    import app.services.ingestion as ingestion
-
+async def test_debug_ingestion_endpoint(test_client, monkeypatch):
     called = {"called": False}
 
     async def fake_run():
         called["called"] = True
 
+    import app.services.ingestion as ingestion
+
     monkeypatch.setattr(ingestion, "run_daily_ingestion", fake_run)
 
-    from app.db.database import Base, engine
-    from app.main import app, scheduler
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        r = await ac.post("/api/v1/debug/run-ingestion")
-        assert r.status_code == 200
-        assert r.json().get("status") == "started"
-
+    r = await test_client.post("/api/v1/debug/run-ingestion")
+    assert r.status_code == 200
+    assert r.json().get("status") == "started"
     assert called["called"]
-
-    # Shutdown scheduler if it's running
-    if scheduler.running:
-        scheduler.shutdown()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,119 @@ async def test_get_trials_returns_list(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_trail_returns_404_for_missing(tmp_path, monkeypatch):
+    db_file = tmp_path / "test3.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
+
+    import app.services.ingestion as ingestion
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr(ingestion, "run_daily_ingestion", noop)
+
+    from app.db.database import Base, engine
+    from app.main import app, scheduler
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        r = await ac.get("/api/v1/trail?trail_id=NCT_MISSING")
+        assert r.status_code == 404
+
+    if scheduler.running:
+        scheduler.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_trail_returns_404_for_non_approved(tmp_path, monkeypatch):
+    db_file = tmp_path / "test4.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
+
+    import app.services.ingestion as ingestion
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr(ingestion, "run_daily_ingestion", noop)
+
+    from app.db.database import Base, engine
+    from app.db.models import ClinicalTrial, TrialStatus
+    from app.main import app, scheduler
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            ClinicalTrial.__table__.insert().values(
+                nct_id="NCT00000001",
+                brief_title="Pending Trial",
+                status=TrialStatus.PENDING_REVIEW,
+            )
+        )
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        r = await ac.get("/api/v1/trail?trail_id=NCT00000001")
+        assert r.status_code == 404
+
+    if scheduler.running:
+        scheduler.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_trail_returns_approved_trial(tmp_path, monkeypatch):
+    db_file = tmp_path / "test5.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.setenv("SKIP_MIGRATIONS", "1")
+
+    import app.services.ingestion as ingestion
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr(ingestion, "run_daily_ingestion", noop)
+
+    from app.db.database import Base, engine
+    from app.db.models import ClinicalTrial, TrialStatus
+    from app.main import app, scheduler
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            ClinicalTrial.__table__.insert().values(
+                nct_id="NCT00000002",
+                brief_title="Approved Osteosarcoma Trial",
+                brief_summary="A phase II trial.",
+                custom_brief_summary="Patient-friendly summary.",
+                key_information="Key facts here.",
+                central_contact_email="contact@example.com",
+                status=TrialStatus.APPROVED,
+            )
+        )
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        r = await ac.get("/api/v1/trail?trail_id=NCT00000002")
+        assert r.status_code == 200
+        body = r.json()
+        assert "result" in body
+        trial = body["result"][0]
+        assert trial["NCTId"] == "NCT00000002"
+        assert trial["BriefTitle"] == "Approved Osteosarcoma Trial"
+        assert trial["CustomBriefSummary"] == "Patient-friendly summary."
+        assert trial["key_information"] == "Key facts here."
+        assert trial["CentralContactEMail"] == "contact@example.com"
+
+    if scheduler.running:
+        scheduler.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_debug_ingestion_endpoint(monkeypatch, tmp_path):
     db_file = tmp_path / "test2.db"
     monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")


### PR DESCRIPTION
Adds the missing endpoint consumed by template-single-study.php on the Osteosarcoma Now website. Returns the full approved trial in the PascalCase JSON shape ({ "result": [...] }) the PHP template expects, with 404 for missing or non-approved trials.

- app/api/endpoints.py: PhpTrialResult + PhpTrialResponse models, GET /trail handler
- templates/template-single-study.php: URL updated to /api/v1/trail, host read from ONTEX_API_BASE WordPress constant instead of hardcoded
- tests/test_api.py: 3 new tests (404-missing, 404-non-approved, 200-approved)
- roadmap.md: Phase 1.7 and full Phase 1 marked complete