### PR TITLE
feat: add admin trial management — edit, move to irrelevant, restore

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -174,6 +174,18 @@ _CUSTOM_FIELDS = [
     "key_information",
 ]
 
+_BASE_FIELDS = [
+    "nct_id", "brief_title", "custom_brief_title", "brief_summary", "custom_brief_summary",
+    "overall_status", "custom_overall_status", "phase", "custom_phase", "study_type",
+    "custom_study_type", "location_country", "custom_location_country", "location_city",
+    "custom_location_city", "minimum_age", "custom_minimum_age", "maximum_age",
+    "custom_maximum_age", "central_contact_name", "custom_central_contact_name",
+    "central_contact_phone", "custom_central_contact_phone", "central_contact_email",
+    "custom_central_contact_email", "eligibility_criteria", "custom_eligibility_criteria",
+    "intervention_description", "custom_intervention_description", "key_information",
+    "last_update_post_date", "custom_last_update_post_date",
+]
+
 
 class ApproveBody(BaseModel):
     username: Optional[str] = None  # Ignored server-side; kept for API backwards-compat
@@ -200,6 +212,48 @@ class ApproveBody(BaseModel):
 class RejectBody(BaseModel):
     username: Optional[str] = None  # Ignored server-side; kept for API backwards-compat
     reviewer_notes: Optional[str] = None
+
+
+class MarkIrrelevantBody(BaseModel):
+    irrelevance_reason: Optional[str] = None
+
+
+class IrrelevantTrialDetail(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    nct_id: str
+    brief_title: str
+    brief_summary: Optional[str]
+    overall_status: Optional[str]
+    phase: Optional[str]
+    study_type: Optional[str]
+    location_country: Optional[str]
+    location_city: Optional[str]
+    minimum_age: Optional[str]
+    maximum_age: Optional[str]
+    central_contact_name: Optional[str]
+    central_contact_phone: Optional[str]
+    central_contact_email: Optional[str]
+    eligibility_criteria: Optional[str]
+    intervention_description: Optional[str]
+    key_information: Optional[str]
+    last_update_post_date: Optional[str]
+    custom_brief_title: Optional[str]
+    custom_brief_summary: Optional[str]
+    custom_overall_status: Optional[str]
+    custom_phase: Optional[str]
+    custom_study_type: Optional[str]
+    custom_location_country: Optional[str]
+    custom_location_city: Optional[str]
+    custom_minimum_age: Optional[str]
+    custom_maximum_age: Optional[str]
+    custom_central_contact_name: Optional[str]
+    custom_central_contact_phone: Optional[str]
+    custom_central_contact_email: Optional[str]
+    custom_eligibility_criteria: Optional[str]
+    custom_intervention_description: Optional[str]
+    custom_last_update_post_date: Optional[str]
+    irrelevance_reason: Optional[str]
 
 
 class TrialsListResponse(BaseModel):
@@ -484,6 +538,43 @@ async def get_irrelevant_trials(
     return IrrelevantTrialsListResponse(items=items, total=total or 0, page=page, page_size=page_size)
 
 
+@router.get("/irrelevant-trials/{nct_id}", response_model=IrrelevantTrialDetail)
+async def get_irrelevant_trial(
+    nct_id: str,
+    _user: dict = Depends(clerk_user),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(IrrelevantTrial).where(IrrelevantTrial.nct_id == nct_id)
+    result = await db.execute(stmt)
+    trial = result.scalars().first()
+    if not trial:
+        raise HTTPException(status_code=404, detail="Irrelevant trial not found")
+    return trial
+
+
+@router.post("/irrelevant-trials/{nct_id}/restore", response_model=TrialDetail)
+async def restore_irrelevant_trial(
+    nct_id: str,
+    _user: dict = Depends(clerk_user),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(IrrelevantTrial).where(IrrelevantTrial.nct_id == nct_id)
+    result = await db.execute(stmt)
+    trial = result.scalars().first()
+    if not trial:
+        raise HTTPException(status_code=404, detail="Irrelevant trial not found")
+
+    restored = ClinicalTrial(
+        **{f: getattr(trial, f) for f in _BASE_FIELDS},
+        status=TrialStatus.PENDING_REVIEW,
+    )
+    db.add(restored)
+    await db.delete(trial)
+    await db.commit()
+    await db.refresh(restored)
+    return restored
+
+
 @router.get("/trail", response_model=PhpTrialResponse)
 async def get_trail(trail_id: str, db: AsyncSession = Depends(get_db)):
     """WordPress PHP template endpoint — returns an approved trial in legacy PascalCase format."""
@@ -598,6 +689,55 @@ async def reject_trial(
     await db.commit()
     await db.refresh(trial)
     return trial
+
+
+@router.patch("/trials/{nct_id}/edit", response_model=TrialDetail)
+async def edit_trial(
+    nct_id: str,
+    body: ApproveBody,
+    _user: dict = Depends(clerk_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update custom fields on any trial without changing its status."""
+    stmt = select(ClinicalTrial).where(ClinicalTrial.nct_id == nct_id)
+    result = await db.execute(stmt)
+    trial = result.scalars().first()
+    if not trial:
+        raise HTTPException(status_code=404, detail="Trial not found")
+
+    for field in _CUSTOM_FIELDS:
+        value = getattr(body, field, None)
+        if value is not None:
+            setattr(trial, field, value)
+
+    await db.commit()
+    await db.refresh(trial)
+    return trial
+
+
+@router.post("/trials/{nct_id}/mark-irrelevant", response_model=IrrelevantTrialDetail)
+async def mark_trial_irrelevant(
+    nct_id: str,
+    body: MarkIrrelevantBody,
+    _user: dict = Depends(clerk_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Move a trial from the relevant table to the irrelevant table."""
+    stmt = select(ClinicalTrial).where(ClinicalTrial.nct_id == nct_id)
+    result = await db.execute(stmt)
+    trial = result.scalars().first()
+    if not trial:
+        raise HTTPException(status_code=404, detail="Trial not found")
+
+    irrelevant = IrrelevantTrial(
+        **{f: getattr(trial, f) for f in _BASE_FIELDS},
+        irrelevance_reason=body.irrelevance_reason,
+    )
+    db.add(irrelevant)
+    await db.delete(trial)
+    await db.commit()
+    await db.refresh(irrelevant)
+    return irrelevant
 
 
 @router.patch("/trials/{nct_id}", response_model=TrialResponse)

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -706,9 +706,8 @@ async def edit_trial(
         raise HTTPException(status_code=404, detail="Trial not found")
 
     for field in _CUSTOM_FIELDS:
-        value = getattr(body, field, None)
-        if value is not None:
-            setattr(trial, field, value)
+        if field in body.model_fields_set:
+            setattr(trial, field, getattr(body, field))
 
     await db.commit()
     await db.refresh(trial)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import type {
   ApproveBody,
+  CustomEdits,
   IrrelevantTrialDetail,
   MarkIrrelevantBody,
   RejectBody,
@@ -125,7 +126,7 @@ export const markTrialIrrelevant = async (nct_id: string, body: MarkIrrelevantBo
   return response.data;
 };
 
-export const editTrial = async (nct_id: string, body: ApproveBody): Promise<TrialDetail> => {
+export const editTrial = async (nct_id: string, body: CustomEdits): Promise<TrialDetail> => {
   const response = await api.patch<TrialDetail>(`/trials/${nct_id}/edit`, body);
   return response.data;
 };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import type {
   ApproveBody,
+  IrrelevantTrialDetail,
+  MarkIrrelevantBody,
   RejectBody,
   TrialDetail,
   TrialListItem,
@@ -105,5 +107,25 @@ export interface GetIrrelevantTrialsParams {
 
 export const getIrrelevantTrials = async (params: GetIrrelevantTrialsParams = {}): Promise<IrrelevantTrialsListResponse> => {
   const response = await api.get<IrrelevantTrialsListResponse>('/irrelevant-trials', { params });
+  return response.data;
+};
+
+export const getIrrelevantTrial = async (nct_id: string): Promise<IrrelevantTrialDetail> => {
+  const response = await api.get<IrrelevantTrialDetail>(`/irrelevant-trials/${nct_id}`);
+  return response.data;
+};
+
+export const restoreIrrelevantTrial = async (nct_id: string): Promise<TrialDetail> => {
+  const response = await api.post<TrialDetail>(`/irrelevant-trials/${nct_id}/restore`, {});
+  return response.data;
+};
+
+export const markTrialIrrelevant = async (nct_id: string, body: MarkIrrelevantBody): Promise<IrrelevantTrialDetail> => {
+  const response = await api.post<IrrelevantTrialDetail>(`/trials/${nct_id}/mark-irrelevant`, body);
+  return response.data;
+};
+
+export const editTrial = async (nct_id: string, body: ApproveBody): Promise<TrialDetail> => {
+  const response = await api.patch<TrialDetail>(`/trials/${nct_id}/edit`, body);
   return response.data;
 };

--- a/frontend/src/components/IrrelevantTrialDetailModal.tsx
+++ b/frontend/src/components/IrrelevantTrialDetailModal.tsx
@@ -15,7 +15,26 @@ export function IrrelevantTrialDetailModal({ nctId, onClose, onRestored }: Props
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    getIrrelevantTrial(nctId).then(setTrial).catch(() => setError('Failed to load trial.'));
+    let cancelled = false;
+
+    setTrial(null);
+    setError(null);
+
+    getIrrelevantTrial(nctId)
+      .then((data) => {
+        if (!cancelled) {
+          setTrial(data);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError('Failed to load trial.');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [nctId]);
 
   async function handleRestore() {

--- a/frontend/src/components/IrrelevantTrialDetailModal.tsx
+++ b/frontend/src/components/IrrelevantTrialDetailModal.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { getIrrelevantTrial, restoreIrrelevantTrial } from '../api';
+import type { IrrelevantTrialDetail } from '../types';
+import { formatPhase, getOverallStatusDisplay } from '../utils/formatters';
+
+interface Props {
+  nctId: string;
+  onClose: () => void;
+  onRestored: (nctId: string) => void;
+}
+
+export function IrrelevantTrialDetailModal({ nctId, onClose, onRestored }: Props) {
+  const [trial, setTrial] = useState<IrrelevantTrialDetail | null>(null);
+  const [restoring, setRestoring] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getIrrelevantTrial(nctId).then(setTrial).catch(() => setError('Failed to load trial.'));
+  }, [nctId]);
+
+  async function handleRestore() {
+    setRestoring(true);
+    setError(null);
+    try {
+      await restoreIrrelevantTrial(nctId);
+      onRestored(nctId);
+      onClose();
+    } catch {
+      setError('Failed to restore trial. Please try again.');
+      setRestoring(false);
+    }
+  }
+
+  const title = trial?.custom_brief_title || trial?.brief_title || '';
+  const summary = trial?.custom_brief_summary || trial?.brief_summary;
+  const status = trial?.custom_overall_status || trial?.overall_status;
+  const phase = trial?.custom_phase || trial?.phase;
+  const statusLabel = status ? getOverallStatusDisplay(status).label : null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex" onClick={onClose}>
+      {/* Backdrop */}
+      <div className="flex-1 bg-black/30" />
+
+      {/* Panel */}
+      <div
+        className="w-full max-w-2xl bg-white shadow-xl flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-6 py-4 border-b shrink-0">
+          <h2 className="text-base font-semibold text-gray-900 leading-snug">
+            {title || <span className="text-gray-400">Loading…</span>}
+          </h2>
+          <button
+            onClick={onClose}
+            className="shrink-0 text-gray-400 hover:text-gray-600 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          {!trial && !error && (
+            <p className="text-sm text-gray-400">Loading…</p>
+          )}
+
+          {error && (
+            <p className="text-sm text-red-600">{error}</p>
+          )}
+
+          {trial && (
+            <>
+              {/* Irrelevance reason */}
+              {trial.irrelevance_reason && (
+                <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-amber-700 mb-1">
+                    Marked irrelevant
+                  </p>
+                  <p className="text-sm text-amber-800">{trial.irrelevance_reason}</p>
+                </div>
+              )}
+
+              {/* Metadata chips */}
+              <div className="flex flex-wrap gap-2">
+                {phase && (
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700">
+                    {formatPhase(phase)}
+                  </span>
+                )}
+                {statusLabel && (
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                    {statusLabel}
+                  </span>
+                )}
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500 font-mono">
+                  {trial.nct_id}
+                </span>
+                {trial.last_update_post_date && (
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500">
+                    Updated {trial.last_update_post_date}
+                  </span>
+                )}
+              </div>
+
+              {/* Summary */}
+              {summary && (
+                <p className="text-sm text-gray-600 leading-relaxed">{summary}</p>
+              )}
+
+              {/* ClinicalTrials.gov link */}
+              <p className="text-xs text-gray-400">
+                <a
+                  href={`https://clinicaltrials.gov/study/${trial.nct_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-gray-600"
+                >
+                  View on ClinicalTrials.gov
+                </a>
+              </p>
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 border-t px-6 py-4 flex items-center justify-between gap-3 bg-white">
+          {error && <p className="text-xs text-red-600">{error}</p>}
+          <div className="flex gap-3 ml-auto">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+            >
+              Close
+            </button>
+            <button
+              onClick={handleRestore}
+              disabled={restoring || !trial}
+              className="px-4 py-2 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {restoring ? 'Restoring…' : 'Restore to Review Queue'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TrialDetailView.tsx
+++ b/frontend/src/components/TrialDetailView.tsx
@@ -21,12 +21,18 @@ interface Props {
   trial: TrialDetail;
   onApprove?: (reviewerNotes: string, edits: CustomEdits) => Promise<void>;
   onReject?: (reviewerNotes: string) => Promise<void>;
+  onEdit?: (edits: CustomEdits) => Promise<void>;
+  onMarkIrrelevant?: (reason: string) => Promise<void>;
+  adminMode?: boolean;
 }
 
-export function TrialDetailView({ trial, onApprove, onReject }: Props) {
+export function TrialDetailView({ trial, onApprove, onReject, onEdit, onMarkIrrelevant, adminMode }: Props) {
   const [edits, setEdits] = useState<CustomEdits>({});
   const [reviewerNotes, setReviewerNotes] = useState(trial.reviewer_notes ?? '');
   const [submitting, setSubmitting] = useState(false);
+  const [editMode, setEditMode] = useState(false);
+  const [markIrrelevantMode, setMarkIrrelevantMode] = useState(false);
+  const [irrelevanceReason, setIrrelevanceReason] = useState('');
 
   function handleFieldChange(field: keyof CustomEdits, value: string) {
     setEdits((prev) => ({ ...prev, [field]: value }));
@@ -52,11 +58,40 @@ export function TrialDetailView({ trial, onApprove, onReject }: Props) {
     }
   }
 
+  async function handleSaveEdit() {
+    if (!onEdit) return;
+    setSubmitting(true);
+    try {
+      await onEdit(edits);
+      setEditMode(false);
+      setEdits({});
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleMarkIrrelevant() {
+    if (!onMarkIrrelevant) return;
+    setSubmitting(true);
+    try {
+      await onMarkIrrelevant(irrelevanceReason);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function cancelEdit() {
+    setEditMode(false);
+    setEdits({});
+    setMarkIrrelevantMode(false);
+    setIrrelevanceReason('');
+  }
+
   const showActions = Boolean(onApprove || onReject);
   const navigate = useNavigate();
 
   // ── Public view ────────────────────────────────────────────────────────────
-  if (!showActions) {
+  if (!showActions && !adminMode) {
     const title    = trial.custom_brief_title    || trial.brief_title;
     const summary  = trial.custom_brief_summary  || trial.brief_summary;
     const status   = trial.custom_overall_status || trial.overall_status;
@@ -186,6 +221,22 @@ export function TrialDetailView({ trial, onApprove, onReject }: Props) {
           <div className="flex items-center gap-2 shrink-0">
             <IngestionEventBadge event={trial.ingestion_event} />
             <StatusBadge status={trial.status} />
+            {adminMode && !editMode && (
+              <button
+                onClick={() => setEditMode(true)}
+                className="px-3 py-1 text-sm font-medium rounded border border-blue-300 text-blue-600 hover:bg-blue-50 transition-colors"
+              >
+                Edit
+              </button>
+            )}
+            {adminMode && editMode && (
+              <button
+                onClick={cancelEdit}
+                className="px-3 py-1 text-sm font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors"
+              >
+                Cancel
+              </button>
+            )}
           </div>
         </div>
 
@@ -251,48 +302,105 @@ export function TrialDetailView({ trial, onApprove, onReject }: Props) {
 
       {/* Trial details */}
       <section>
-        {showActions && (
+        {(showActions || editMode) && (
           <div className="grid grid-cols-2 gap-3 mb-2">
             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide">Official (ClinicalTrials.gov)</p>
             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide">Custom (AI / Admin)</p>
           </div>
         )}
-        <OfficialVsCustomPanel trial={trial} edits={edits} onChange={showActions ? handleFieldChange : undefined} />
+        <OfficialVsCustomPanel trial={trial} edits={edits} onChange={(showActions || editMode) ? handleFieldChange : undefined} />
       </section>
 
       {/* Reviewer notes + action buttons */}
-      {showActions && (
+      {(showActions || editMode) && (
         <section className="sticky bottom-0 bg-white border-t pt-4 -mx-6 px-6 pb-2">
-          <div className="mb-3">
-            <label className="block text-xs font-medium text-gray-500 mb-1">Reviewer notes (optional)</label>
-            <textarea
-              className="w-full border border-gray-300 rounded p-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-400"
-              rows={2}
-              placeholder="Add a note for the record…"
-              value={reviewerNotes}
-              onChange={(e) => setReviewerNotes(e.target.value)}
-            />
-          </div>
-          <div className="flex gap-3 justify-end">
-            {onReject && (
-              <button
-                onClick={handleReject}
-                disabled={submitting}
-                className="px-4 py-2 text-sm font-medium rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50"
-              >
-                Reject
-              </button>
-            )}
-            {onApprove && (
-              <button
-                onClick={handleApprove}
-                disabled={submitting}
-                className="px-4 py-2 text-sm font-medium rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
-              >
-                Approve
-              </button>
-            )}
-          </div>
+          {showActions && (
+            <div className="mb-3">
+              <label className="block text-xs font-medium text-gray-500 mb-1">Reviewer notes (optional)</label>
+              <textarea
+                className="w-full border border-gray-300 rounded p-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-400"
+                rows={2}
+                placeholder="Add a note for the record…"
+                value={reviewerNotes}
+                onChange={(e) => setReviewerNotes(e.target.value)}
+              />
+            </div>
+          )}
+
+          {showActions && (
+            <div className="flex gap-3 justify-end">
+              {onReject && (
+                <button
+                  onClick={handleReject}
+                  disabled={submitting}
+                  className="px-4 py-2 text-sm font-medium rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50"
+                >
+                  Reject
+                </button>
+              )}
+              {onApprove && (
+                <button
+                  onClick={handleApprove}
+                  disabled={submitting}
+                  className="px-4 py-2 text-sm font-medium rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+                >
+                  Approve
+                </button>
+              )}
+            </div>
+          )}
+
+          {editMode && (
+            <>
+              {!markIrrelevantMode ? (
+                <div className="flex gap-3 justify-between">
+                  {onMarkIrrelevant && (
+                    <button
+                      onClick={() => setMarkIrrelevantMode(true)}
+                      className="px-4 py-2 text-sm rounded border border-orange-300 text-orange-600 hover:bg-orange-50 transition-colors"
+                    >
+                      Move to Irrelevant
+                    </button>
+                  )}
+                  {onEdit && (
+                    <button
+                      onClick={handleSaveEdit}
+                      disabled={submitting}
+                      className="px-4 py-2 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 ml-auto"
+                    >
+                      Save Changes
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <label className="block text-xs font-medium text-gray-500">Reason for marking irrelevant (optional)</label>
+                  <textarea
+                    value={irrelevanceReason}
+                    onChange={(e) => setIrrelevanceReason(e.target.value)}
+                    rows={2}
+                    placeholder="Why is this trial not relevant?"
+                    className="w-full border border-gray-300 rounded p-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-orange-300"
+                  />
+                  <div className="flex gap-3 justify-end">
+                    <button
+                      onClick={() => setMarkIrrelevantMode(false)}
+                      className="px-4 py-2 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleMarkIrrelevant}
+                      disabled={submitting}
+                      className="px-4 py-2 text-sm font-medium rounded bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50"
+                    >
+                      Confirm
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
         </section>
       )}
     </div>

--- a/frontend/src/pages/AllTrialsPage.tsx
+++ b/frontend/src/pages/AllTrialsPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { getIrrelevantTrials, getTrialFacets, getTrials } from '../api';
 import type { GetIrrelevantTrialsParams, GetTrialsParams, IrrelevantTrialListItem, IrrelevantTrialsListResponse, TrialFacets } from '../api';
 import { IngestionEventBadge } from '../components/IngestionEventBadge';
+import { IrrelevantTrialDetailModal } from '../components/IrrelevantTrialDetailModal';
 import { StatusBadge } from '../components/StatusBadge';
 import type { TrialListItem, TrialsListResponse } from '../types';
 import { formatPhase, getOverallStatusDisplay } from '../utils/formatters';
@@ -212,6 +213,7 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
     sort_by: 'last_update_post_date',
   });
   const [searchInput, setSearchInput] = useState('');
+  const [selectedIrrelevantId, setSelectedIrrelevantId] = useState<string | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Fetch facets once for filter dropdowns (public mode only)
@@ -483,7 +485,7 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
                 {irrelevantResponse.items.map((trial: IrrelevantTrialListItem) => {
                   const statusDisplay = getOverallStatusDisplay(trial.overall_status);
                   return (
-                    <li key={trial.nct_id} className="px-6 py-4">
+                    <li key={trial.nct_id} onClick={() => setSelectedIrrelevantId(trial.nct_id)} className="px-6 py-4 hover:bg-gray-50 cursor-pointer transition-colors">
                       <p className="text-sm font-semibold text-gray-900 leading-snug mb-1">
                         {trial.brief_title}
                       </p>
@@ -605,6 +607,21 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
             Next
           </button>
         </div>
+      )}
+
+      {selectedIrrelevantId && (
+        <IrrelevantTrialDetailModal
+          nctId={selectedIrrelevantId}
+          onClose={() => setSelectedIrrelevantId(null)}
+          onRestored={(id) => {
+            setIrrelevantResponse((prev) =>
+              prev
+                ? { ...prev, items: prev.items.filter((t) => t.nct_id !== id), total: prev.total - 1 }
+                : prev
+            );
+            setSelectedIrrelevantId(null);
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/AllTrialsPage.tsx
+++ b/frontend/src/pages/AllTrialsPage.tsx
@@ -485,7 +485,19 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
                 {irrelevantResponse.items.map((trial: IrrelevantTrialListItem) => {
                   const statusDisplay = getOverallStatusDisplay(trial.overall_status);
                   return (
-                    <li key={trial.nct_id} onClick={() => setSelectedIrrelevantId(trial.nct_id)} className="px-6 py-4 hover:bg-gray-50 cursor-pointer transition-colors">
+                    <li
+                      key={trial.nct_id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setSelectedIrrelevantId(trial.nct_id)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          setSelectedIrrelevantId(trial.nct_id);
+                        }
+                      }}
+                      className="px-6 py-4 hover:bg-gray-50 cursor-pointer transition-colors"
+                    >
                       <p className="text-sm font-semibold text-gray-900 leading-snug mb-1">
                         {trial.brief_title}
                       </p>

--- a/frontend/src/pages/TrialDetailPage.tsx
+++ b/frontend/src/pages/TrialDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '@clerk/clerk-react';
-import { approveTrial, getTrial, rejectTrial } from '../api';
+import { approveTrial, editTrial, getTrial, markTrialIrrelevant, rejectTrial } from '../api';
 import { TrialDetailView } from '../components/TrialDetailView';
 import type { CustomEdits, TrialDetail } from '../types';
 
@@ -39,6 +39,18 @@ export function TrialDetailPage() {
     setDetail(updated);
   }
 
+  async function handleEdit(edits: CustomEdits) {
+    if (!nct_id) return;
+    const updated = await editTrial(nct_id, edits);
+    setDetail(updated);
+  }
+
+  async function handleMarkIrrelevant(reason: string) {
+    if (!nct_id) return;
+    await markTrialIrrelevant(nct_id, { irrelevance_reason: reason || undefined });
+    navigate('/admin/trials');
+  }
+
   if (notFound) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-3">
@@ -67,6 +79,9 @@ export function TrialDetailPage() {
         trial={detail}
         onApprove={canReview ? handleApprove : undefined}
         onReject={canReview ? handleReject : undefined}
+        onEdit={isSignedIn ? handleEdit : undefined}
+        onMarkIrrelevant={isSignedIn ? handleMarkIrrelevant : undefined}
+        adminMode={!!isSignedIn}
       />
     </div>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -105,3 +105,43 @@ export interface RejectBody {
 }
 
 export type CustomEdits = Partial<Omit<ApproveBody, 'reviewer_notes'>>;
+
+export interface IrrelevantTrialDetail {
+  nct_id: string;
+  brief_title: string;
+  brief_summary: string | null;
+  overall_status: string | null;
+  phase: string | null;
+  study_type: string | null;
+  location_country: string | null;
+  location_city: string | null;
+  minimum_age: string | null;
+  maximum_age: string | null;
+  central_contact_name: string | null;
+  central_contact_phone: string | null;
+  central_contact_email: string | null;
+  eligibility_criteria: string | null;
+  intervention_description: string | null;
+  key_information: string | null;
+  last_update_post_date: string | null;
+  custom_brief_title: string | null;
+  custom_brief_summary: string | null;
+  custom_overall_status: string | null;
+  custom_phase: string | null;
+  custom_study_type: string | null;
+  custom_location_country: string | null;
+  custom_location_city: string | null;
+  custom_minimum_age: string | null;
+  custom_maximum_age: string | null;
+  custom_central_contact_name: string | null;
+  custom_central_contact_phone: string | null;
+  custom_central_contact_email: string | null;
+  custom_eligibility_criteria: string | null;
+  custom_intervention_description: string | null;
+  custom_last_update_post_date: string | null;
+  irrelevance_reason: string | null;
+}
+
+export interface MarkIrrelevantBody {
+  irrelevance_reason?: string;
+}


### PR DESCRIPTION
Admins can now edit custom fields on any trial (not just PENDING_REVIEW), move relevant trials to irrelevant with an optional reason, and restore irrelevant trials back to the review queue. Irrelevant trial cards are now clickable and open a detail modal with a restore action.

Backend: 4 new endpoints (GET/POST irrelevant-trials/{id}/restore, PATCH trials/{id}/edit, POST trials/{id}/mark-irrelevant). Frontend: edit mode button in TrialDetailView header (admin only), IrrelevantTrialDetailModal component, clickable irrelevant cards.