### PR TITLE
Fix run ingestion button disappearing without interaction

### DIFF
--- a/frontend/src/components/IngestionDashboardModal.tsx
+++ b/frontend/src/components/IngestionDashboardModal.tsx
@@ -62,6 +62,9 @@ export function IngestionDashboardModal({ onClose }: { onClose: () => void }) {
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const headersRef = useRef<Record<string, string>>({});
+  // True once this client has observed an in-progress run. Prevents showing
+  // a stale summary from a previous run when the modal first opens.
+  const sawRunningRef = useRef(false);
 
   // ── Auth headers ─────────────────────────────────────────────────────────────
   useEffect(() => {
@@ -103,11 +106,13 @@ export function IngestionDashboardModal({ onClose }: { onClose: () => void }) {
         const data: LiveStatus = await res.json();
         setStatus(data);
 
-        if (data.error && !done) {
+        if (data.running) sawRunningRef.current = true;
+
+        if (data.error && !done && sawRunningRef.current) {
           clearInterval(intervalRef.current!);
           setErrorMsg(data.error);
           setDone(true);
-        } else if (data.summary && !done) {
+        } else if (data.summary && !done && sawRunningRef.current) {
           clearInterval(intervalRef.current!);
           setSummary(data.summary);
           setDone(true);

--- a/frontend/src/components/IngestionDashboardModal.tsx
+++ b/frontend/src/components/IngestionDashboardModal.tsx
@@ -140,6 +140,9 @@ export function IngestionDashboardModal({ onClose }: { onClose: () => void }) {
     setErrorMsg(null);
     setSummary(null);
     setDone(false);
+    // Re-arm the gate so a stale summary from a previous run can't match
+    // before /start has cleared it on the backend.
+    sawRunningRef.current = false;
     try {
       const res = await fetch(`${API_URL}/ingestion/start`, {
         method: 'POST',
@@ -148,6 +151,12 @@ export function IngestionDashboardModal({ onClose }: { onClose: () => void }) {
       if (!res.ok && res.status !== 409) {
         setErrorMsg(`Failed to start: ${res.status}`);
         setDone(true);
+      } else {
+        // /start clears the backend summary before returning, so any
+        // non-null summary we see from here on belongs to this run —
+        // including sub-poll-tick runs that finish before we observe
+        // running=true.
+        sawRunningRef.current = true;
       }
     } catch {
       setErrorMsg('Could not reach server.');


### PR DESCRIPTION


# Pull Request

## Description

The admin ingestion modal was displaying the previous run's summaryimmediately on open, because the backend's /ingestion/status returns the last-known summary from module-level state. Gate the summary and error handlers on a sawRunningRef, set only after a poll observes running=true, so the green "Run complete" box appears only for runs this client actually witnessed.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
