### PR TITLE
feat: skip re-review when UPDATED trial content is unchanged

### DIFF
--- a/alembic/versions/006_add_skipped_unchanged_to_ingestion_runs.py
+++ b/alembic/versions/006_add_skipped_unchanged_to_ingestion_runs.py
@@ -1,0 +1,30 @@
+"""add_skipped_unchanged_to_ingestion_runs
+
+Revision ID: 006_add_skipped_unchanged
+Revises: 005_drop_ai_matching_criteria
+Create Date: 2026-04-20
+
+Adds skipped_unchanged column to ingestion_runs. Tracks how many UPDATED trials
+were silently skipped because only last_update_post_date changed, not content.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "006_add_skipped_unchanged"
+down_revision: Union[str, None] = "005_drop_ai_matching_criteria"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ingestion_runs",
+        sa.Column("skipped_unchanged", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ingestion_runs", "skipped_unchanged")

--- a/alembic/versions/006_add_skipped_unchanged_to_ingestion_runs.py
+++ b/alembic/versions/006_add_skipped_unchanged_to_ingestion_runs.py
@@ -22,8 +22,21 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.add_column(
         "ingestion_runs",
-        sa.Column("skipped_unchanged", sa.Integer(), nullable=True),
+        sa.Column(
+            "skipped_unchanged",
+            sa.Integer(),
+            nullable=True,
+            server_default=sa.text("0"),
+        ),
     )
+    op.execute(
+        sa.text(
+            "UPDATE ingestion_runs "
+            "SET skipped_unchanged = 0 "
+            "WHERE skipped_unchanged IS NULL"
+        )
+    )
+    op.alter_column("ingestion_runs", "skipped_unchanged", nullable=False)
 
 
 def downgrade() -> None:

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -138,4 +138,5 @@ class IngestionRun(Base):
     irrelevant_processed: Mapped[int] = mapped_column(Integer, default=0)
     fetch_errors: Mapped[int] = mapped_column(Integer, default=0)
     classify_errors: Mapped[int] = mapped_column(Integer, default=0)
+    skipped_unchanged: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -138,5 +138,5 @@ class IngestionRun(Base):
     irrelevant_processed: Mapped[int] = mapped_column(Integer, default=0)
     fetch_errors: Mapped[int] = mapped_column(Integer, default=0)
     classify_errors: Mapped[int] = mapped_column(Integer, default=0)
-    skipped_unchanged: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    skipped_unchanged: Mapped[int] = mapped_column(Integer, default=0)
 

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -9,6 +9,7 @@ PIPELINE OVERVIEW
 Step 1  Collect NCT IDs + last-update dates for each search term
 Step 2  Classify each NCT ID against the database (new / updated / rejected / no-change)
 Step 3  Fetch full trial data from ClinicalTrials.gov API v2
+Step 3.6 Skip UPDATED trials whose content hasn't changed (date-only bumps)
 Step 4  Classify relevance with AI (confident / unsure / reject)
 Step 5  Generate patient-friendly custom_* fields via AI summarisation (confident/unsure only)
 Step 6  Upsert into clinical_trials or irrelevant_trials
@@ -35,7 +36,7 @@ import logging
 from datetime import datetime
 from typing import Any, Callable, Coroutine, List, Optional
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from app.core.config import settings
 from app.db.database import SessionLocal
@@ -236,6 +237,10 @@ async def run_daily_ingestion(
         "central_contact_name", "central_contact_phone", "central_contact_email",
         "eligibility_criteria", "intervention_description", "last_update_post_date",
     ]
+    # Content fields exclude last_update_post_date: a date change is what triggered
+    # the UPDATED path, so we compare everything *except* the date to decide whether
+    # actual content changed and a re-review is needed.
+    _CONTENT_FIELDS = [f for f in _SNAPSHOT_FIELDS if f != "last_update_post_date"]
 
     if trials_with_existing_edits:
         fetched_existing_ids = {
@@ -253,18 +258,64 @@ async def run_daily_ingestion(
                             for field in _CUSTOM_FIELDS
                             if getattr(row, field) is not None
                         }
-                        # Capture approval metadata only from ClinicalTrial rows
-                        if isinstance(row, ClinicalTrial) and row.approved_at:
-                            existing_approval_map[row.nct_id] = {
-                                "approved_at": row.approved_at,
-                                "approved_by": row.approved_by,
-                            }
-                            # Snapshot the current official fields before the merge
-                            # overwrites them — used by the diff view in the review queue
+                        # Capture approval metadata and snapshot for ClinicalTrial rows
+                        if isinstance(row, ClinicalTrial):
+                            # Snapshot ALL existing trials for content-change comparison
+                            # (Step 3.6), not just approved ones.
                             existing_snapshot_map[row.nct_id] = {
                                 field: getattr(row, field)
                                 for field in _SNAPSHOT_FIELDS
                             }
+                            if row.approved_at:
+                                existing_approval_map[row.nct_id] = {
+                                    "approved_at": row.approved_at,
+                                    "approved_by": row.approved_by,
+                                }
+
+    # ──────────────────────────────────────────────────────────
+    # STEP 3.6 — Skip UPDATED trials whose content hasn't changed
+    # ClinicalTrials.gov sometimes bumps last_update_post_date without changing
+    # any actual content (administrative touches). For those trials, skip
+    # re-classification, re-summarisation, and status reset — just silently
+    # update the date columns so future runs don't flag them again.
+    # ──────────────────────────────────────────────────────────
+    updated_nct_id_set = set(updated_trials)
+    content_unchanged: list[str] = []
+
+    # Collect date + trial_data for candidates before mutating fetched
+    unchanged_candidates: dict[str, dict] = {
+        td["nct_id"]: td
+        for td in fetched
+        if td.get("nct_id") in updated_nct_id_set
+        and td.get("nct_id") in existing_snapshot_map
+        and all(
+            td.get(f) == existing_snapshot_map[td["nct_id"]].get(f)
+            for f in _CONTENT_FIELDS
+        )
+    }
+
+    if unchanged_candidates:
+        content_unchanged = list(unchanged_candidates.keys())
+        fetched = [td for td in fetched if td.get("nct_id") not in unchanged_candidates]
+
+        async with SessionLocal() as db:
+            for nct_id, td in unchanged_candidates.items():
+                new_date = td.get("last_update_post_date")
+                await db.execute(
+                    update(ClinicalTrial)
+                    .where(ClinicalTrial.nct_id == nct_id)
+                    .values(
+                        last_update_post_date=new_date,
+                        custom_last_update_post_date=new_date,
+                    )
+                )
+            await db.commit()
+
+        await emit({
+            "step": "unchanged_skipped",
+            "label": "Skipped (content unchanged)",
+            "count": len(content_unchanged),
+        })
 
     # ──────────────────────────────────────────────────────────
     # STEP 4 — Relevance classification
@@ -349,7 +400,8 @@ async def run_daily_ingestion(
     newly_irrelevant = 0
 
     # Used to set ingestion_event: updated_trials are UPDATED, everything else is NEW
-    updated_nct_ids = set(updated_trials)
+    # content_unchanged trials were already handled in Step 3.6 and removed from fetched.
+    updated_nct_ids = updated_nct_id_set
 
     async with SessionLocal() as db:
         for trial_data in to_summarize:
@@ -402,12 +454,13 @@ async def run_daily_ingestion(
             search_terms=json.dumps(search_terms),
             candidates_found=len(all_candidates),
             new_trials=len(new_trials),
-            updated_trials=len(updated_trials),
+            updated_trials=len(updated_trials) - len(content_unchanged),
             reeval_trials=len(reeval_list),
             relevant_processed=processed,
             irrelevant_processed=newly_irrelevant,
             fetch_errors=fetch_errors,
             classify_errors=classify_errors,
+            skipped_unchanged=len(content_unchanged),
         ))
         await db.commit()
 
@@ -415,7 +468,8 @@ async def run_daily_ingestion(
         "step": "complete",
         "label": "Done",
         "new": len(new_trials),
-        "updated": len(updated_trials),
+        "updated": len(updated_trials) - len(content_unchanged),
+        "skipped_unchanged": len(content_unchanged),
         "relevant": processed,
         "irrelevant": newly_irrelevant,
         "fetch_errors": fetch_errors,
@@ -423,12 +477,13 @@ async def run_daily_ingestion(
     })
 
     logger.info(
-        "Ingestion complete: %d new, %d updated, %d re-evaluated | "
+        "Ingestion complete: %d new, %d updated, %d skipped (unchanged), %d re-evaluated | "
         "%d relevant (PENDING_REVIEW), %d irrelevant | "
         "%d fetch errors, %d classify errors | "
         "search_terms=%s, total_candidates=%d",
         len(new_trials),
-        len(updated_trials),
+        len(updated_trials) - len(content_unchanged),
+        len(content_unchanged),
         len(reeval_list),
         processed,
         newly_irrelevant,

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -19,12 +19,13 @@ Covers:
 import json
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from unittest.mock import AsyncMock, MagicMock
 
 from app.db.database import Base
-from app.db.models import ClinicalTrial, IngestionEvent, IrrelevantTrial, TrialStatus
+from app.db.models import ClinicalTrial, IngestionEvent, IngestionRun, IrrelevantTrial, TrialStatus
 from app.services.ai.schemas import ClassificationResult, ConfidenceLabel
 from app.services.ctgov.study_detail import map_api_to_model
 
@@ -264,6 +265,71 @@ async def test_updated_trial_resets_status_to_pending_review(tmp_path, monkeypat
         assert trial is not None
         assert trial.status == TrialStatus.PENDING_REVIEW
         assert trial.last_update_post_date == "2024-09-01"
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_updated_trial_with_unchanged_content_is_skipped(tmp_path, monkeypatch):
+    """An APPROVED trial with only a newer date should skip re-review/re-classification."""
+    engine, factory = _make_test_db(tmp_path, "test3_unchanged.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    trial_dict = make_trial_dict(nct_id="NCT33333334", last_update="2024-09-01")
+
+    async with factory() as db:
+        existing_payload = trial_dict.copy()
+        existing_payload["last_update_post_date"] = "2024-01-01"
+        existing_payload["custom_last_update_post_date"] = "2024-01-01"
+        existing = ClinicalTrial(
+            **existing_payload,
+            status=TrialStatus.APPROVED,
+        )
+        db.add(existing)
+        await db.commit()
+
+    classify_mock = AsyncMock(return_value=make_classification())
+    summarize_mock = AsyncMock(return_value=FAKE_AI_SUMMARIES)
+
+    monkeypatch.setattr("app.services.ingestion.SessionLocal", factory)
+    monkeypatch.setattr(
+        "app.services.ingestion.iter_study_index_rows",
+        lambda **kwargs: [("NCT33333334", "2024-09-01")],
+    )
+    monkeypatch.setattr(
+        "app.services.ingestion.fetch_full_study",
+        lambda nct_id: {"protocolSection": {}},
+    )
+    monkeypatch.setattr(
+        "app.services.ingestion.map_api_to_model",
+        lambda raw: trial_dict.copy(),
+    )
+    monkeypatch.setattr("app.services.ingestion.AIClient", lambda: _make_mock_ai_client())
+    monkeypatch.setattr("app.services.ingestion.ai_generate_summaries", summarize_mock)
+    monkeypatch.setattr("app.services.ingestion.classify_trial", classify_mock)
+
+    from app.services.ingestion import run_daily_ingestion
+    await run_daily_ingestion(search_terms=["osteosarcoma"])
+
+    classify_mock.assert_not_awaited()
+    summarize_mock.assert_not_awaited()
+
+    async with factory() as db:
+        trial = await db.get(ClinicalTrial, "NCT33333334")
+        assert trial is not None
+        assert trial.status == TrialStatus.APPROVED
+        assert trial.last_update_post_date == "2024-09-01"
+        assert trial.custom_last_update_post_date == "2024-09-01"
+
+        run = (
+            await db.execute(select(IngestionRun).order_by(IngestionRun.id.desc()))
+        ).scalars().first()
+        assert run is not None
+        assert run.updated_trials == 0
+        assert run.skipped_unchanged == 1
+        assert run.relevant_processed == 0
+        assert run.irrelevant_processed == 0
 
     await engine.dispose()
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -271,17 +271,18 @@ async def test_updated_trial_resets_status_to_pending_review(tmp_path, monkeypat
 
 @pytest.mark.asyncio
 async def test_updated_trial_with_unchanged_content_is_skipped(tmp_path, monkeypatch):
-    """An APPROVED trial with only a newer date should skip re-review/re-classification."""
+    """An APPROVED trial with only an updated last_update_post_date should skip re-review/re-classification."""
     engine, factory = _make_test_db(tmp_path, "test3_unchanged.db")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
+    old_update_date = "2024-01-01"
     trial_dict = make_trial_dict(nct_id="NCT33333334", last_update="2024-09-01")
 
     async with factory() as db:
         existing_payload = trial_dict.copy()
-        existing_payload["last_update_post_date"] = "2024-01-01"
-        existing_payload["custom_last_update_post_date"] = "2024-01-01"
+        existing_payload["last_update_post_date"] = old_update_date
+        existing_payload["custom_last_update_post_date"] = old_update_date
         existing = ClinicalTrial(
             **existing_payload,
             status=TrialStatus.APPROVED,
@@ -322,9 +323,8 @@ async def test_updated_trial_with_unchanged_content_is_skipped(tmp_path, monkeyp
         assert trial.last_update_post_date == "2024-09-01"
         assert trial.custom_last_update_post_date == "2024-09-01"
 
-        run = (
-            await db.execute(select(IngestionRun).order_by(IngestionRun.id.desc()))
-        ).scalars().first()
+        run = await db.execute(select(IngestionRun).order_by(IngestionRun.id.desc()))
+        run = run.scalars().first()
         assert run is not None
         assert run.updated_trials == 0
         assert run.skipped_unchanged == 1


### PR DESCRIPTION
ClinicalTrials.gov sometimes bumps last_update_post_date without changing any content (administrative touches). Previously this caused approved trials to be reset to PENDING_REVIEW needlessly.

Step 3.6 now compares all content fields (excluding the date) against the existing DB snapshot. If nothing changed, the trial is skipped — only the date columns are silently updated. Genuinely changed trials still go through full re-classification and review.

Also tracks skipped_unchanged count in IngestionRun for observability.