### PR TITLE
60 bug not all trials get contact information

### DIFF
--- a/frontend/src/components/OfficialVsCustomPanel.tsx
+++ b/frontend/src/components/OfficialVsCustomPanel.tsx
@@ -12,6 +12,9 @@ const FIELDS: Field[] = [
   { label: 'Brief Summary', officialKey: 'brief_summary', customKey: 'custom_brief_summary', multiline: true },
   { label: 'Overall Status', officialKey: 'overall_status', customKey: 'custom_overall_status' },
   { label: 'Phase', officialKey: 'phase', customKey: 'custom_phase' },
+  { label: 'Key Contact Name', officialKey: 'central_contact_name', customKey: 'custom_central_contact_name' },
+  { label: 'Key Contact Phone', officialKey: 'central_contact_phone', customKey: 'custom_central_contact_phone' },
+  { label: 'Key Contact Email', officialKey: 'central_contact_email', customKey: 'custom_central_contact_email' },
   { label: 'Eligibility Criteria', officialKey: 'eligibility_criteria', customKey: 'custom_eligibility_criteria', multiline: true },
   { label: 'Intervention', officialKey: 'intervention_description', customKey: 'custom_intervention_description', multiline: true },
 ];

--- a/frontend/src/components/TrialDetailView.tsx
+++ b/frontend/src/components/TrialDetailView.tsx
@@ -164,17 +164,30 @@ export function TrialDetailView({ trial, onApprove, onReject, onEdit, onMarkIrre
 
             {/* Column 3 */}
             <div className="space-y-5">
-              {(contact || phone || email) && (
-                <InfoField label="Key Contact">
-                  {contact && <p>{contact}</p>}
-                  {phone   && <p className="text-gray-500">{phone}</p>}
-                  {email   && (
-                    <a href={`mailto:${email}`} className="text-blue-600 hover:underline break-all">
-                      {email}
+              <InfoField label="Key Contact">
+                {(contact || phone || email) ? (
+                  <>
+                    {contact && <p>{contact}</p>}
+                    {phone   && <p className="text-gray-500">{phone}</p>}
+                    {email   && (
+                      <a href={`mailto:${email}`} className="text-blue-600 hover:underline break-all">
+                        {email}
+                      </a>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-gray-500">
+                    <a
+                      href={`https://clinicaltrials.gov/study/${trial.nct_id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      View ClinicalTrials.gov for details.
                     </a>
-                  )}
-                </InfoField>
-              )}
+                  </p>
+                )}
+              </InfoField>
               <InfoField label="Clinical Trial ID">
                 <span className="font-mono">{trial.nct_id}</span>
               </InfoField>

--- a/frontend/src/components/TrialDetailView.tsx
+++ b/frontend/src/components/TrialDetailView.tsx
@@ -183,7 +183,7 @@ export function TrialDetailView({ trial, onApprove, onReject, onEdit, onMarkIrre
                       rel="noopener noreferrer"
                       className="text-blue-600 hover:underline"
                     >
-                      View ClinicalTrials.gov for details.
+                      View trial on ClinicalTrials.gov
                     </a>
                   </p>
                 )}


### PR DESCRIPTION
# Pull Request

## Description

Some trials display no contact info on the public trial detail page because they have no central contact on ClinicalTrials.gov (only per-site contacts that differ between locations, e.g. `NCT04851119`). Previously the "Key Contact" block was hidden entirely in this case, which made it look like the trial had no contact route at all.

This PR makes two small display-only changes:

1. **Public view** ([`TrialDetailView.tsx`](frontend/src/components/TrialDetailView.tsx)): "Key Contact" InfoField now always renders. When the primary contact is null, it shows a link `View trial on ClinicalTrials.gov` (deep-links to that trial's page) instead of hiding the block. No claim is made about why the contact is missing.
2. **Admin view** ([`OfficialVsCustomPanel.tsx`](frontend/src/components/OfficialVsCustomPanel.tsx)): added `central_contact_name`, `central_contact_phone`, `central_contact_email` as rows in the Official-vs-Custom panel. Admins can now see and edit the contact fields side-by-side, which was previously not possible (admin view rendered no contact at all).

**Important — scope:**
This is purely a frontend display change. No backend / mapper / DB / migration changes. The DB still stores `NULL` when ClinicalTrials.gov provides no central contact — that is factually correct and should not be polluted with display strings.

**Caveat for the legacy WordPress page:**
The legacy `templates/template-single-study.php` template still prints `-` when the contact is null. 
If we end up not linking to our page from OSN but populating it directly we need the same fallback there. 
- Mirror the change in the PHP template (single-line swap of `-` for the same link).
- Or, only if we want the fallback to flow uniformly to **any** renderer, store the fallback as a value in the DB. Not recommended (conflates data with presentation), but flagged for completeness.

**Possible follow-up — admin contact picker:**
We discussed a richer alternative for admins: store all available contacts (central + per-location) in a new column, and give the admin a dropdown to pick one as the displayed contact, with a "Primary" label on the central contact when present. That feature was descoped from this PR to keep the change minimal. If the current fallback proves insufficient, that is the natural next step.

Fixes #60

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Purely a display change, no test needed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — n/a, change is self-explanatory
- [ ] I have made corresponding changes to the documentation — n/a
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — display-only change, covered by manual verification
- [x] New and existing unit tests pass locally with my changes
