### PR TITLE
Skip trials on AI classification failure instead of storing as unsure

### DIFF
--- a/app/services/ai/AGENT.md
+++ b/app/services/ai/AGENT.md
@@ -125,9 +125,12 @@ This agent does NOT fetch data, write to DB, or generate summaries.
 
 - All failures (including invalid JSON responses, timeouts, and other API errors)
   may be retried according to the AI client's configured retry policy (e.g. `max_retries`).
-- After retries are exhausted, return the safe default:
-  `is_relevant=true, confidence=0.0, reason="AI evaluation failed — needs manual review"`
-- **NEVER silently drop a trial.** On any failure (after applying the retry policy), default to RELEVANT.
+- After retries are exhausted, return a `ClassificationResult` with `failed=True`
+  (label `unsure`, `reason="AI evaluation failed: <error>"`).
+- The `failed` flag tells the ingestion pipeline to **skip the trial entirely this
+  run** — no row is written — so the trial is refetched and re-evaluated on the next
+  daily run rather than parked with a verdict the AI never actually made.
+- A genuine `unsure`/`reject`/`confident` verdict always has `failed=False`.
 
 ---
 

--- a/app/services/ai/AGENT.md
+++ b/app/services/ai/AGENT.md
@@ -131,6 +131,26 @@ This agent does NOT fetch data, write to DB, or generate summaries.
   run** — no row is written — so the trial is refetched and re-evaluated on the next
   daily run rather than parked with a verdict the AI never actually made.
 - A genuine `unsure`/`reject`/`confident` verdict always has `failed=False`.
+- `failed` is set by our code only. Never trust a `failed` field coming back from the
+  LLM's JSON — the client overrides it to `False` when parsing a successful response.
+
+### Why skipping is safe (this used to say "NEVER silently drop a trial")
+
+Dropping the trial for one run is not data loss, because **nothing is written**:
+
+- A **new** trial gets no row, so the next run still sees it as new.
+- An **updated** trial keeps its old `last_update_post_date`, so it still mismatches
+  CT.gov and Step 2's date diff flags it as updated again.
+- A **rejected** trial stays in `irrelevant_trials` with its old date, so re-evaluation
+  is triggered again.
+
+In every case the trial resurfaces on the next daily run and is re-classified then. The
+alternative — storing `unsure` — is worse: it puts a verdict the AI never made in front
+of the editorial team, and once the row exists with a current date, the date diff stops
+flagging it, so the AI never looks at that trial again.
+
+The cost is that a sustained LLM outage means a day (or more) of no ingestion. That is
+visible as `classify_errors` on the ingestion run record and in the admin dashboard.
 
 ---
 

--- a/app/services/ai/client.py
+++ b/app/services/ai/client.py
@@ -102,11 +102,14 @@ class AIClient:
                     "classify_trial attempt %d failed: %s", attempt + 1, e
                 )
 
-        # Never lose a trial — default to unsure so editorial team can review
+        # The AI call genuinely failed (outage/error). Flag it as failed so the
+        # ingestion pipeline skips this trial entirely and refetches it next run,
+        # rather than storing a bogus "unsure" verdict the AI never actually made.
         logger.error(
             "classify_trial failed after %d attempts: %s", 1 + max_retries, last_error
         )
         return ClassificationResult(
             label=ConfidenceLabel.UNSURE,
-            reason="AI evaluation failed -- needs manual review",
+            reason=f"AI evaluation failed: {last_error}",
+            failed=True,
         )

--- a/app/services/ai/client.py
+++ b/app/services/ai/client.py
@@ -79,7 +79,11 @@ class AIClient:
         temperature: float = 0.1,
         max_retries: int = 2,
     ) -> ClassificationResult:
-        """Classify a trial via LLM. Returns a safe default on failure (never loses a trial)."""
+        """Classify a trial via LLM.
+
+        On failure after retries, returns a result with `failed=True` so the caller
+        can skip the trial rather than store a verdict the AI never made.
+        """
         last_error: Exception | None = None
 
         for attempt in range(1 + max_retries):
@@ -95,7 +99,8 @@ class AIClient:
                 )
                 raw = response.choices[0].message.content
                 data = json.loads(raw)
-                return ClassificationResult(**data)
+                # `failed` is ours, not the model's — never let the LLM set it.
+                return ClassificationResult(**{**data, "failed": False})
             except Exception as e:
                 last_error = e
                 logger.warning(

--- a/app/services/ai/client.py
+++ b/app/services/ai/client.py
@@ -108,8 +108,9 @@ class AIClient:
         logger.error(
             "classify_trial failed after %d attempts: %s", 1 + max_retries, last_error
         )
+        reason = f"AI evaluation failed: {last_error}"
         return ClassificationResult(
             label=ConfidenceLabel.UNSURE,
-            reason=f"AI evaluation failed: {last_error}",
+            reason=reason[:500],
             failed=True,
         )

--- a/app/services/ai/schemas.py
+++ b/app/services/ai/schemas.py
@@ -12,3 +12,7 @@ class ConfidenceLabel(str, Enum):
 class ClassificationResult(BaseModel):
     label: ConfidenceLabel
     reason: str = Field(max_length=500)
+    # True only when the AI call itself failed (LLM outage/error), as opposed to a
+    # genuine verdict. Failed classifications are skipped by the ingestion pipeline
+    # so the trial is refetched and re-evaluated on the next daily run.
+    failed: bool = False

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -15,7 +15,9 @@ Step 3.6 Skip both UPDATED clinical_trials AND re-evaluated irrelevant_trials
          whose only changes are in settings.IGNORED_UPDATE_FIELDS (e.g. date,
          location, contact info). Affected rows have their official_* fields
          silently synced - no AI re-classification, no status reset.
-Step 4  Classify relevance with AI (confident / unsure / reject)
+Step 4  Classify relevance with AI (confident / unsure / reject). If the AI call
+        itself fails (outage/error), the trial is skipped entirely this run — no row
+        is written — so Step 2's date-diff logic refetches and re-evaluates it next run.
 Step 5  Generate patient-friendly custom_* fields via AI summarisation (confident/unsure only)
 Step 6  Upsert into clinical_trials or irrelevant_trials; promote previously-
         rejected NCTs to clinical_trials (and delete their IrrelevantTrial row)
@@ -37,6 +39,7 @@ Status assignment in Step 6:
   - AI label "confident" → APPROVED, approved_by="ai" (auto-published, no human review)
   - AI label "unsure"    → PENDING_REVIEW (queued for editorial review)
   - AI label "reject"    → IrrelevantTrial table (not in ClinicalTrial at all)
+  - AI call failed       → skipped entirely (no row written); refetched next run
 
 This means an updated trial that the AI re-classifies as confident stays APPROVED
 without bouncing back to PENDING_REVIEW. Updated trials that drop to "unsure" do
@@ -367,7 +370,6 @@ async def run_daily_ingestion(
     # If OPENROUTER_API_KEY is not set, AIClient raises RuntimeError here.
     # ──────────────────────────────────────────────────────────
     ai_client = AIClient()
-    classify_errors = 0
     classify_total = len(fetched)
 
     # classifications[nct_id] = ClassificationResult
@@ -386,11 +388,12 @@ async def run_daily_ingestion(
             classification = await classify_trial(ai_client, trial_data)
         except Exception as exc:
             logger.error("classify_trial raised for %s: %s", nct_id, exc)
-            classify_errors += 1
-            # Fail-safe: include for manual review rather than silently skip
+            # Genuine AI failure: flag it so this trial is skipped (not stored) and
+            # refetched on the next run, rather than parked as a bogus "unsure".
             classification = ClassificationResult(
                 label=ConfidenceLabel.UNSURE,
-                reason=f"Classification error — needs manual review: {exc}",
+                reason=f"Classification error: {exc}",
+                failed=True,
             )
         classifications[nct_id] = classification
         await emit({
@@ -400,16 +403,23 @@ async def run_daily_ingestion(
             "total": classify_total,
         })
 
-    # Split fetched trials: only confident/unsure get AI summaries
+    # Trials whose classification genuinely failed (LLM outage/error) are written
+    # NOWHERE this run — leaving the DB untouched so Step 2's date-diff logic
+    # refetches and re-evaluates them on the next daily run.
+    failed_ids = {nct for nct, c in classifications.items() if c.failed}
+    classify_errors = len(failed_ids)
+
+    # Split fetched trials: only confident/unsure (and not failed) get AI summaries;
+    # reject (and not failed) go to the irrelevant table; failed go nowhere.
     to_summarize = [
         td for td in fetched
-        if classifications.get(td.get("nct_id"), ClassificationResult(
-            label=ConfidenceLabel.REJECT, reason=""
-        )).label != ConfidenceLabel.REJECT
+        if td.get("nct_id") not in failed_ids
+        and classifications[td.get("nct_id")].label != ConfidenceLabel.REJECT
     ]
     to_reject = [
         td for td in fetched
-        if td not in to_summarize
+        if td.get("nct_id") not in failed_ids
+        and classifications[td.get("nct_id")].label == ConfidenceLabel.REJECT
     ]
 
     # ──────────────────────────────────────────────────────────
@@ -548,12 +558,13 @@ async def run_daily_ingestion(
         "irrelevant": newly_irrelevant,
         "fetch_errors": fetch_errors,
         "classify_errors": classify_errors,
+        "ai_failed_skipped": classify_errors,
     })
 
     logger.info(
         "Ingestion complete: %d new, %d updated, %d skipped (unchanged), %d re-evaluated | "
         "%d relevant (%d auto-approved, %d pending review), %d irrelevant | "
-        "%d fetch errors, %d classify errors | "
+        "%d fetch errors, %d classify failures (skipped, will retry next run) | "
         "search_terms=%s, total_candidates=%d",
         len(new_trials),
         updated_trials_count,

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -392,7 +392,9 @@ async def run_daily_ingestion(
             # refetched on the next run, rather than parked as a bogus "unsure".
             classification = ClassificationResult(
                 label=ConfidenceLabel.UNSURE,
-                reason=f"Classification error: {exc}",
+                # Truncated: reason has max_length=500, and a ValidationError
+                # raised here would abort the whole run.
+                reason=f"Classification error: {exc}"[:500],
                 failed=True,
             )
         classifications[nct_id] = classification
@@ -558,6 +560,7 @@ async def run_daily_ingestion(
         "irrelevant": newly_irrelevant,
         "fetch_errors": fetch_errors,
         "classify_errors": classify_errors,
+    })
 
     logger.info(
         "Ingestion complete: %d new, %d updated, %d skipped (unchanged), %d re-evaluated | "

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -558,8 +558,6 @@ async def run_daily_ingestion(
         "irrelevant": newly_irrelevant,
         "fetch_errors": fetch_errors,
         "classify_errors": classify_errors,
-        "ai_failed_skipped": classify_errors,
-    })
 
     logger.info(
         "Ingestion complete: %d new, %d updated, %d skipped (unchanged), %d re-evaluated | "

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -128,7 +128,7 @@ Classifies whether the trial is relevant to osteosarcoma patients:
 | `unsure` | Possibly relevant — proceeds to summarisation and queued for editorial review (`status=PENDING_REVIEW`) |
 | `reject` | No osteosarcoma connection — written directly to `irrelevant_trials`, no summary generated |
 
-**Fail-safe:** classification errors default to `unsure` so the trial is included for manual review.
+**AI failure:** if the LLM call itself fails (outage/error after retries), the trial is **skipped entirely** — no row is written — and refetched on the next daily run via the Step 2 date-diff logic. This avoids storing a verdict the AI never actually made. (A genuine `unsure` verdict, by contrast, is stored as `PENDING_REVIEW`.)
 
 - Temperature: 0.1
 - Retries: 2
@@ -207,7 +207,7 @@ Schema: [app/db/models.py](../app/db/models.py)
 |------|---------|-----------|
 | 1 — Fetch index | API/network error | Ingestion aborted |
 | 3 — Fetch study | HTTP error or timeout | Trial skipped; `fetch_errors++` |
-| 4 — AI classify | LLM error after retries | Defaults to `unsure`; logged as `classify_errors` |
+| 4 — AI classify | LLM error after retries | Trial skipped (no row written), refetched next run; logged as `classify_errors` |
 | 5 — AI summarise | LLM error after retries | `custom_*` fields left `None`; pipeline continues |
 | 6 — DB upsert | SQL error | Exception propagates; run aborted |
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -142,7 +142,7 @@ Create a new function `ai_generate_summaries(client, trial_data: dict) -> dict` 
 
 12 unit tests in `tests/test_ai_services.py`:
 - `ai_generate_summaries()`: success, LLM returns None (null dict), extra keys ignored
-- `classify_trial()`: confident/unsure/reject labels returned unchanged; AIClient fail-safe returns `unsure` so no trial is silently lost
+- `classify_trial()`: confident/unsure/reject labels returned unchanged; on AI failure AIClient returns `failed=True` so the ingestion pipeline skips the trial and refetches it next run
 - `AIClient`: JSON parse success for generate and classify, all-retries-exhausted returns None / safe default
 
 #### 2.3 API endpoint tests ✅

--- a/tests/test_ai_services.py
+++ b/tests/test_ai_services.py
@@ -178,7 +178,7 @@ async def test_ai_client_classify_trial_parses_json_on_success(ai_client):
 
 
 @pytest.mark.asyncio
-async def test_ai_client_classify_trial_returns_safe_default_on_failure(ai_client):
+async def test_ai_client_classify_trial_flags_failed_on_failure(ai_client):
     ai_client._client.chat.completions.create = AsyncMock(
         side_effect=RuntimeError("API down")
     )
@@ -186,5 +186,6 @@ async def test_ai_client_classify_trial_returns_safe_default_on_failure(ai_clien
     result = await ai_client.classify_trial("sys", "user", max_retries=0)
 
     assert isinstance(result, ClassificationResult)
-    assert result.label == ConfidenceLabel.UNSURE
-    assert "needs manual review" in result.reason
+    # failed=True is what makes the ingestion pipeline skip the trial and refetch it.
+    assert result.failed is True
+    assert "AI evaluation failed" in result.reason

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -14,7 +14,7 @@ Covers:
 - Missing nct_id from map_api_to_model: trial skipped
 - Missing brief_title from API: map_api_to_model uses safe fallback
 - AI summarisation failure: custom_* fields remain None, trial still processed
-- AI classification failure: safe default (label=unsure, PENDING_REVIEW)
+- AI classification failure: trial skipped (no row written), refetched next run
 - Admin-edited custom_* fields preserved on re-ingestion
 """
 
@@ -956,9 +956,10 @@ async def test_ai_summarisation_failure_trial_still_processed(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_ai_classification_failure_defaults_to_unsure(tmp_path, monkeypatch):
-    """If classify_trial raises an exception, the trial should default to unsure
-    so no trial is silently lost."""
+async def test_ai_classification_failure_skips_new_trial(tmp_path, monkeypatch):
+    """If classify_trial raises (genuine AI failure), a new trial is written to
+    NEITHER table — it is skipped so the next daily run refetches and re-evaluates it
+    rather than parking it with a verdict the AI never made."""
     engine, factory = _make_test_db(tmp_path, "test9.db")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
@@ -993,10 +994,80 @@ async def test_ai_classification_failure_defaults_to_unsure(tmp_path, monkeypatc
     await run_daily_ingestion(search_terms=["osteosarcoma"])
 
     async with factory() as db:
-        trial = await db.get(ClinicalTrial, "NCT99999999")
+        assert await db.get(ClinicalTrial, "NCT99999999") is None
+        assert await db.get(IrrelevantTrial, "NCT99999999") is None
+        run = (await db.execute(select(IngestionRun))).scalars().one()
+        assert run.classify_errors == 1
+        assert run.relevant_processed == 0
+        assert run.irrelevant_processed == 0
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ai_classification_failure_leaves_existing_approved_trial_untouched(
+    tmp_path, monkeypatch
+):
+    """When re-classification of an already-APPROVED trial fails, its existing row is
+    left exactly as it was (status, content, stored date) — so it still has a date
+    mismatch against CT.gov and gets refetched/re-evaluated on the next run."""
+    engine, factory = _make_test_db(tmp_path, "test9b.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with factory() as db:
+        db.add(ClinicalTrial(
+            nct_id="NCT90000000",
+            brief_title="Old Title",
+            last_update_post_date="2024-01-01",
+            status=TrialStatus.APPROVED,
+            approved_by=AI_APPROVER,
+            ai_relevance_label="confident",
+        ))
+        await db.commit()
+
+    # CT.gov reports a newer date → trial qualifies as "updated" and is re-fetched.
+    trial_dict = make_trial_dict(nct_id="NCT90000000", last_update="2024-09-01")
+
+    monkeypatch.setattr("app.services.ingestion.SessionLocal", factory)
+    monkeypatch.setattr(
+        "app.services.ingestion.iter_study_index_rows",
+        lambda **kwargs: [("NCT90000000", "2024-09-01")],
+    )
+    monkeypatch.setattr(
+        "app.services.ingestion.fetch_full_study",
+        lambda nct_id: {"protocolSection": {}},
+    )
+    monkeypatch.setattr(
+        "app.services.ingestion.map_api_to_model",
+        lambda raw: trial_dict.copy(),
+    )
+    monkeypatch.setattr("app.services.ingestion.AIClient", lambda: _make_mock_ai_client())
+    monkeypatch.setattr(
+        "app.services.ingestion.ai_generate_summaries",
+        AsyncMock(return_value=FAKE_AI_SUMMARIES),
+    )
+    # AIClient-level fail-safe path: returns a failed=True result rather than raising.
+    monkeypatch.setattr(
+        "app.services.ingestion.classify_trial",
+        AsyncMock(return_value=ClassificationResult(
+            label=ConfidenceLabel.UNSURE,
+            reason="AI evaluation failed: boom",
+            failed=True,
+        )),
+    )
+
+    from app.services.ingestion import run_daily_ingestion
+    await run_daily_ingestion(search_terms=["osteosarcoma"])
+
+    async with factory() as db:
+        trial = await db.get(ClinicalTrial, "NCT90000000")
         assert trial is not None
-        assert trial.status == TrialStatus.PENDING_REVIEW
-        assert trial.ai_relevance_label == "unsure"
+        # Untouched: old content and stored date preserved, still APPROVED.
+        assert trial.status == TrialStatus.APPROVED
+        assert trial.brief_title == "Old Title"
+        assert trial.last_update_post_date == "2024-01-01"
+        assert trial.ai_relevance_label == "confident"
 
     await engine.dispose()
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -984,10 +984,12 @@ async def test_ai_classification_failure_skips_new_trial(tmp_path, monkeypatch):
         "app.services.ingestion.ai_generate_summaries",
         AsyncMock(return_value=FAKE_AI_SUMMARIES),
     )
-    # Classification raises an unexpected exception
+    # Classification raises an unexpected exception. The message is deliberately
+    # longer than ClassificationResult.reason's max_length=500 — the handler must
+    # truncate it, not blow up with a ValidationError and abort the run.
     monkeypatch.setattr(
         "app.services.ingestion.classify_trial",
-        AsyncMock(side_effect=RuntimeError("OpenAI timeout")),
+        AsyncMock(side_effect=RuntimeError("OpenAI timeout " * 50)),
     )
 
     from app.services.ingestion import run_daily_ingestion


### PR DESCRIPTION
Skip trials on AI classification failure instead of storing as unsure

When the AI relevance classification (Step 4) failed due to an LLM outage/error, the trial was written as PENDING_REVIEW with a bogus "AI evaluation failed" verdict. Because the row carried CT.govs current last_update_post_date, the next daily run skipped it -- permanently parking a verdict the AI never actually made.

Now a genuine classification failure is flagged (ClassificationResult.failed) and the trial is written nowhere this run. Step 2s existing date-diff logic refetches and re-evaluates it on the next run until the AI recovers. Any existing row for an updated/re-eval trial is left untouched.

Scope: classification only. Summary-generation failures keep their existing fail-safe (stored with custom_brief_summary=None for admin fill-in).