### PR TITLE
Keep the public header on one row on phones

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -67,6 +67,12 @@ That is the one intentional `blue-*` left in the codebase.
 - **No emoji as iconography**, and no text glyphs (`▾`, `→`) used as UI chrome.
 - **Muted chips.** The three classification labels are soft tints (`accent-50`,
   `brand-50`, `surface-muted`), not saturated pills.
+- **The public header stays on one row.** Logo left, nav links right, down to 320px.
+  The links hold their intrinsic width (`shrink-0`, `whitespace-nowrap`) and the logo
+  is the flexible element — `min-w-0` on its link plus `max-w-full` on the image lets
+  it scale below `max-h-7` when space runs out. Don't add `flex-wrap` back: a wrapped
+  header pushes the nav onto a second row on a phone, and letting the logo win instead
+  forces horizontal scroll on every page.
 
 ## Icons and document metadata
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -27,23 +27,25 @@ export function Layout({
     return (
       <div className="min-h-screen bg-surface flex flex-col">
         {/*
-          The logo is 5.6:1, so at h-10 it plus both links needs ~465px. Below that
-          the row wraps instead of forcing the whole document wider than the
-          viewport, which used to push every page into horizontal scroll on a phone.
+          One row at every width. The links keep their intrinsic width (shrink-0,
+          no wrapping mid-label) and the logo absorbs whatever is left: it is
+          5.6:1 with height driven by max-height, so max-w-full plus min-w-0 on
+          its flex item lets it scale down instead of wrapping the row or forcing
+          the document wider than the viewport.
         */}
-        <nav className="bg-white border-b border-line px-4 sm:px-6 py-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-3 shrink-0">
-          <Link to="/" className="flex items-center gap-2">
+        <nav className="bg-white border-b border-line px-4 sm:px-6 py-3 flex items-center justify-between gap-x-3 sm:gap-x-4 shrink-0">
+          <Link to="/" className="flex items-center gap-2 min-w-0">
             <img
               src="/osn-bardo-logo.png"
               alt="Osteosarcoma Now — managed by Bardo Foundation"
-              className="max-h-8 w-auto max-w-full sm:max-h-10"
+              className="max-h-7 w-auto max-w-full sm:max-h-10"
             />
           </Link>
-          <div className="flex items-center gap-4 sm:gap-6">
+          <div className="flex items-center gap-3 shrink-0 sm:gap-6">
             <NavLink
               to="/trials"
               className={({ isActive }) =>
-                `text-sm font-medium ${isActive ? 'text-brand-600' : 'text-gray-600 hover:text-gray-900'}`
+                `text-xs sm:text-sm font-medium whitespace-nowrap ${isActive ? 'text-brand-600' : 'text-gray-600 hover:text-gray-900'}`
               }
             >
               Search Trials
@@ -51,13 +53,13 @@ export function Layout({
             {isSignedIn ? (
               <NavLink
                 to="/admin"
-                className="text-sm font-medium text-brand-600 hover:text-brand-700"
+                className="text-xs sm:text-sm font-medium whitespace-nowrap text-brand-600 hover:text-brand-700"
               >
                 Admin Dashboard
               </NavLink>
             ) : (
               <SignInButton mode="redirect" forceRedirectUrl="/admin">
-                <button className="text-sm font-medium text-brand-600 hover:text-brand-700">
+                <button className="text-xs sm:text-sm font-medium whitespace-nowrap text-brand-600 hover:text-brand-700">
                   Admin Login
                 </button>
               </SignInButton>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -59,7 +59,7 @@ export function Layout({
               </NavLink>
             ) : (
               <SignInButton mode="redirect" forceRedirectUrl="/admin">
-                <button className="text-xs sm:text-sm font-medium whitespace-nowrap text-brand-600 hover:text-brand-700">
+                <button type="button" className="text-xs sm:text-sm font-medium whitespace-nowrap text-brand-600 hover:text-brand-700">
                   Admin Login
                 </button>
               </SignInButton>


### PR DESCRIPTION
## Problem

On a phone the public header wrapped to two rows — the OSN/Bardo logo on the first, `Search Trials` / `Admin Dashboard` on the second. The previous layout used `flex-wrap` deliberately, as the lesser of two evils: without it the logo refused to shrink and forced horizontal scroll on every page.

## Fix

Invert which element gives way. The links become rigid and the logo becomes flexible:

- `shrink-0` + `whitespace-nowrap` on the links, so they keep their intrinsic width and never break mid-label.
- `min-w-0` on the logo's `<Link>`, which is what actually lets the image's existing `max-w-full` take effect — a flex item's default `min-width: auto` was pinning it to the image's natural width and causing the wrap.
- Mobile link text drops to `text-xs` (`sm:text-sm` unchanged) and gaps tighten to `gap-3` / `gap-x-3`, which buys the logo back enough width to stay legible.
- Mobile logo cap goes `max-h-8` → `max-h-7`; `sm:max-h-10` is unchanged, so nothing above 640px moves.

No `flex-wrap`, so the row can't break; the logo scales instead.

## Verification

Headless Chrome against the production CSS bundle, measuring the real markup at 320 / 360 / 375 / 390 / 414 / 430 / 540 / 639 / 640 / 768 / 1024px — one row and no horizontal overflow at every width. Measured with the signed-in labels, since `Admin Dashboard` is wider than `Admin Login`.

| viewport | logo w×h | links w | one row | overflow |
| --- | --- | --- | --- | --- |
| 320 | 98×17 | 178 | yes | no |
| 375 | 153×27 | 178 | yes | no |
| 390 | 158×28 | 178 | yes | no |
| 430 | 158×28 | 178 | yes | no |
| 640 | 226×40 | 217 | yes | no |

`tsc --noEmit`, `eslint`, and `npm run build` all pass. The admin layout is untouched.

`docs/DESIGN.md` gains a rule recording why `flex-wrap` shouldn't come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
