### PR TITLE
Filter trials by actual CT.gov status instead of three fixed buckets

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -411,7 +411,10 @@ async def get_trial_facets(
     country_stmt = select(country_field).where(country_field.isnot(None)).distinct()
     status_stmt = (
         select(ClinicalTrial.overall_status, func.count())
-        .where(ClinicalTrial.overall_status.isnot(None))
+        .where(
+            ClinicalTrial.overall_status.isnot(None),
+            ClinicalTrial.overall_status != "",
+        )
         .group_by(ClinicalTrial.overall_status)
     )
     if not is_authenticated:

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -352,30 +352,73 @@ class PhpTrialResponse(BaseModel):
 # so FastAPI does not match the literal "review-queue" as a path parameter.
 # ──────────────────────────────────────────────────────────────────────────────
 
+class StatusFacet(BaseModel):
+    value: str
+    count: int
+
+
 class TrialFacets(BaseModel):
     countries: List[str]
+    statuses: List[StatusFacet]
+
+
+# Display order for recruitment-status filter options: statuses a patient can act
+# on first, then closed-to-enrolment, then stopped/finished. Not a grouping — every
+# status is its own filter option; this only decides the order they are listed in.
+# Any status absent from this list (e.g. one CT.gov adds later) is appended
+# alphabetically, so it always remains filterable.
+_STATUS_DISPLAY_ORDER = [
+    "RECRUITING",
+    "NOT_YET_RECRUITING",
+    "ENROLLING_BY_INVITATION",
+    "AVAILABLE",
+    "TEMPORARILY_NOT_AVAILABLE",
+    "ACTIVE_NOT_RECRUITING",
+    "APPROVED_FOR_MARKETING",
+    "NO_LONGER_AVAILABLE",
+    "SUSPENDED",
+    "COMPLETED",
+    "TERMINATED",
+    "WITHDRAWN",
+    "WITHHELD",
+    "UNKNOWN",
+]
+_STATUS_DISPLAY_ORDER_SET = set(_STATUS_DISPLAY_ORDER)
 
 
 @router.get("/trials/facets", response_model=TrialFacets)
-async def get_trial_facets(db: AsyncSession = Depends(get_db)):
+async def get_trial_facets(
+    clerk_user_claims: Optional[dict] = Depends(optional_clerk_user),
+    db: AsyncSession = Depends(get_db),
+):
     """
-    Return distinct filterable values from approved trials.
+    Return distinct filterable values from the trials the caller can see.
 
     - countries: sorted list of individual country names (split from comma-joined location_country)
+    - statuses: overall_status values actually present, with counts, in _STATUS_DISPLAY_ORDER
+
+    Visibility matches GET /trials: anonymous callers get facets over APPROVED
+    trials only, authenticated callers get facets over all trials. This keeps the
+    filter options and the results they produce in agreement — a status is only
+    offered as an option when at least one visible trial actually has it.
     """
+    is_authenticated = clerk_user_claims is not None
+
     country_field = func.coalesce(
         ClinicalTrial.custom_location_country,
         ClinicalTrial.location_country,
     )
-    stmt = (
-        select(country_field)
-        .where(
-            ClinicalTrial.status == TrialStatus.APPROVED,
-            country_field.isnot(None),
-        )
-        .distinct()
+    country_stmt = select(country_field).where(country_field.isnot(None)).distinct()
+    status_stmt = (
+        select(ClinicalTrial.overall_status, func.count())
+        .where(ClinicalTrial.overall_status.isnot(None))
+        .group_by(ClinicalTrial.overall_status)
     )
-    result = await db.execute(stmt)
+    if not is_authenticated:
+        country_stmt = country_stmt.where(ClinicalTrial.status == TrialStatus.APPROVED)
+        status_stmt = status_stmt.where(ClinicalTrial.status == TrialStatus.APPROVED)
+
+    result = await db.execute(country_stmt)
     raw_countries = [row[0] for row in result.fetchall()]
 
     # location_country may be comma-joined (e.g. "United States, Norway")
@@ -386,7 +429,19 @@ async def get_trial_facets(db: AsyncSession = Depends(get_db)):
             if country:
                 unique.add(country)
 
-    return TrialFacets(countries=sorted(unique))
+    result = await db.execute(status_stmt)
+    counts = {row[0]: row[1] for row in result.fetchall()}
+    statuses = [
+        StatusFacet(value=value, count=counts[value])
+        for value in _STATUS_DISPLAY_ORDER
+        if value in counts
+    ] + [
+        StatusFacet(value=value, count=counts[value])
+        for value in sorted(counts)
+        if value not in _STATUS_DISPLAY_ORDER_SET
+    ]
+
+    return TrialFacets(countries=sorted(unique), statuses=statuses)
 
 
 @router.get("/trials/review-queue", response_model=List[TrialListItem])
@@ -403,10 +458,6 @@ async def get_review_queue(
     result = await db.execute(stmt)
     return result.scalars().all()
 
-
-_RECRUITING_NOW = ["RECRUITING"]
-_NOT_RECRUITING = ["NOT_YET_RECRUITING", "ACTIVE_NOT_RECRUITING", "ENROLLING_BY_INVITATION"]
-_FINISHED = ["COMPLETED", "TERMINATED", "WITHDRAWN", "SUSPENDED"]
 
 # ── Age filtering helpers ──────────────────────────────────────────────────────
 # minimum_age / maximum_age are free-text strings from ClinicalTrials.gov,
@@ -450,7 +501,7 @@ async def get_trials(
     q: Optional[str] = None,
     ingestion_event: Optional[IngestionEvent] = None,
     phase: Optional[str] = None,
-    recruiting_status: Optional[str] = None,
+    overall_status: Optional[str] = None,
     country: Optional[str] = None,
     age_group: Optional[str] = None,
     sort_by: Optional[str] = None,
@@ -466,7 +517,8 @@ async def get_trials(
     - status: filter by PENDING_REVIEW / APPROVED / REJECTED
     - ingestion_event: filter by NEW / UPDATED
     - phase: substring match on phase field (e.g. "PHASE1" matches "PHASE1" and "PHASE1_PHASE2")
-    - recruiting_status: "recruiting" | "not_recruiting" | "finished"
+    - overall_status: pipe-separated CT.gov status values, OR'd together
+      (e.g. "RECRUITING|NOT_YET_RECRUITING"). Mirrors CT.gov's own filter syntax.
     - country: substring match on location_country (handles comma-joined multi-country values)
     - age_group: "child" | "adult" | "older_adult" — Python-side filter (age strings can't be compared in SQL)
     - sort_by: "last_update_post_date" (default, desc) or "brief_title" (asc)
@@ -484,12 +536,10 @@ async def get_trials(
         stmt = stmt.where(ClinicalTrial.ingestion_event == ingestion_event)
     if phase:
         stmt = stmt.where(ClinicalTrial.phase.ilike(f"%{phase}%"))
-    if recruiting_status == "recruiting":
-        stmt = stmt.where(ClinicalTrial.overall_status.in_(_RECRUITING_NOW))
-    elif recruiting_status == "not_recruiting":
-        stmt = stmt.where(ClinicalTrial.overall_status.in_(_NOT_RECRUITING))
-    elif recruiting_status == "finished":
-        stmt = stmt.where(ClinicalTrial.overall_status.in_(_FINISHED))
+    if overall_status:
+        wanted = [s.strip().upper() for s in overall_status.split("|") if s.strip()]
+        if wanted:
+            stmt = stmt.where(ClinicalTrial.overall_status.in_(wanted))
     if country:
         stmt = stmt.where(ClinicalTrial.location_country.ilike(f"%{country}%"))
     if q:

--- a/docs/trial-status-filtering.md
+++ b/docs/trial-status-filtering.md
@@ -1,0 +1,110 @@
+# Recruitment status filtering
+
+How ONTEX filters trials by their ClinicalTrials.gov recruitment status
+(`overall_status`), and why it is built the way it is.
+
+## The bug this design replaced
+
+A clinician asked to refer a patient to
+[NCT07630974](https://clinicaltrials.gov/study/NCT07630974). The trial was
+approved and live on OSN, but they could not find it and concluded it was
+missing. It wasn't — the filter hid it:
+
+- The trial's status was `NOT_YET_RECRUITING`.
+- Filtering by **"Recruiting now"** excluded it.
+- Its only other home was a filter called **"Not currently recruiting"**, which
+  reads as *closed* — no reason to look there when placing a referral.
+- Meanwhile its badge read **"Not yet recruiting"**, a label that appeared
+  nowhere in the filter list.
+
+So one trial was described two different ways at the same moment, and the
+label that would have found it was never shown. The reporter reasonably
+assumed ClinicalTrials.gov had renamed a status. They had not: `overall_status`
+had genuinely changed from `NOT_YET_RECRUITING` to `RECRUITING` on 2026-07-06,
+and "Not currently recruiting" was never a CT.gov status at all — it was our
+own group label, inherited from the legacy WordPress template.
+
+Two structural faults made this possible:
+
+1. **Three hardcoded buckets covered only 8 of CT.gov's 14 statuses.** The
+   other six (`UNKNOWN`, `AVAILABLE`, `NO_LONGER_AVAILABLE`,
+   `TEMPORARILY_NOT_AVAILABLE`, `APPROVED_FOR_MARKETING`, `WITHHELD`) belonged
+   to no bucket, so *every* filter option excluded them. In our osteosarcoma
+   search set that is 104 of 848 trials — 12%, mostly `UNKNOWN`.
+2. **The bucket lists were triplicated** across the API, the review queue, and
+   the badge label map, with nothing keeping them in sync.
+
+## How it works now
+
+**The API filters on individual statuses. Groups exist only in the UI.**
+
+### Backend
+
+`GET /trials?overall_status=RECRUITING|NOT_YET_RECRUITING` takes a
+pipe-separated list of raw CT.gov values, OR'd together — the same syntax
+CT.gov's own API uses. Values are upper-cased and blanks dropped, so
+`recruiting| |` is valid. There is no notion of a group server-side.
+
+`GET /trials/facets` returns `statuses: [{value, count}]` — the statuses that
+*actually occur* in the caller's visible trials, ordered by
+`_STATUS_DISPLAY_ORDER` (patient-actionable first, then closed to enrolment,
+then stopped/finished). Anything not in that list is appended alphabetically,
+so a status CT.gov introduces later still becomes a filter option on its own.
+
+The endpoint is auth-aware, matching `GET /trials`: anonymous callers get
+facets over `APPROVED` trials only, authenticated callers over all trials.
+This keeps options and results in agreement — an option is offered only when
+at least one visible trial has that status.
+
+### Frontend
+
+`STATUS_GROUPS` in `frontend/src/utils/formatters.ts` is the **single** place
+groupings are defined. A group is just a preset that ticks its member
+statuses; selecting one sends `overall_status=A|B|C`.
+
+`groupStatuses(available)` intersects the groups with the statuses actually
+present and returns leftovers as `ungrouped`, which callers render as
+standalone options. **This is what guarantees no trial can be unreachable** —
+a status missing from every group still gets its own checkbox.
+
+- **Public search sidebar** — group checkboxes, collapsed by default, expanding
+  to the individual statuses within. Multi-select, with counts.
+- **Admin dropdowns** (All Trials, Review Queue) — native `<optgroup>`s, with an
+  "All \<group\>" entry above each group's individual statuses.
+
+## Why groups are presentation-only
+
+Patients and families do not know CT.gov vocabulary; "Enrolling by invitation"
+means little without context. Plain-English groups help them. But encoding
+those groups in the data model is what caused the original bug — statuses
+outside a bucket became invisible, and the group label overrode the trial's
+real one.
+
+Keeping groups in the view layer gives both: plain-English scaffolding at the
+top level, exact CT.gov statuses one click down, and an API where every status
+is equally addressable.
+
+## Adding or changing a group
+
+Edit `STATUS_GROUPS` in `frontend/src/utils/formatters.ts`. Nothing else needs
+to change — not the API, not the database, not the tests for the filter
+itself. A status you remove from a group simply becomes a standalone option
+rather than disappearing.
+
+To change the order options are listed in, edit `_STATUS_DISPLAY_ORDER` in
+`app/api/endpoints.py`.
+
+## A note on the label
+
+The middle group is deliberately named **"Not recruiting yet or no longer
+recruiting"** rather than the old "Not currently recruiting". It names both
+ends of what it contains. The old wording implied *closed*, which is what hid
+not-yet-recruiting trials — the ones still worth a referral — from the person
+looking for them.
+
+## Known gap
+
+Filtering uses `overall_status` only, not `custom_overall_status`. An admin
+override changes the badge (`TrialDetailView.tsx`) but not which filter the
+trial answers to. The countries facet does coalesce the two; statuses do not.
+Deliberate, to keep the change contained — worth revisiting.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -40,7 +40,8 @@ export interface GetTrialsParams {
   q?: string;
   ingestion_event?: string;
   phase?: string;
-  recruiting_status?: string;
+  /** Pipe-separated CT.gov status values, OR'd (e.g. "RECRUITING|NOT_YET_RECRUITING"). */
+  overall_status?: string;
   country?: string;
   age_group?: string;
   sort_by?: string;
@@ -48,8 +49,15 @@ export interface GetTrialsParams {
   page_size?: number;
 }
 
+export interface StatusFacet {
+  value: string;
+  count: number;
+}
+
 export interface TrialFacets {
   countries: string[];
+  /** overall_status values present in the visible trials, in display order. */
+  statuses: StatusFacet[];
 }
 
 export const getReviewQueue = async (): Promise<TrialListItem[]> => {

--- a/frontend/src/pages/AllTrialsPage.tsx
+++ b/frontend/src/pages/AllTrialsPage.tsx
@@ -564,7 +564,7 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
               <FilterSection title="Recruiting Status">
                 <StatusFilter
                   statuses={facets.statuses}
-                  selected={params.overall_status?.split('|').filter(Boolean) ?? []}
+                  selected={params.overall_status?.split('|').map((s) => s.trim()).filter(Boolean) ?? []}
                   onChange={(next) =>
                     setParams((p) => ({ ...p, overall_status: next.join('|') || undefined, page: 1 }))
                   }

--- a/frontend/src/pages/AllTrialsPage.tsx
+++ b/frontend/src/pages/AllTrialsPage.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getIrrelevantTrials, getTrialFacets, getTrials } from '../api';
-import type { GetIrrelevantTrialsParams, GetTrialsParams, IrrelevantTrialListItem, IrrelevantTrialsListResponse, TrialFacets } from '../api';
+import type { GetIrrelevantTrialsParams, GetTrialsParams, IrrelevantTrialListItem, IrrelevantTrialsListResponse, StatusFacet, TrialFacets } from '../api';
 import { IngestionEventBadge } from '../components/IngestionEventBadge';
 import { IrrelevantTrialDetailModal } from '../components/IrrelevantTrialDetailModal';
 import { StatusBadge } from '../components/StatusBadge';
 import type { TrialListItem, TrialsListResponse } from '../types';
-import { formatLocationSummary, formatPhase, getOverallStatusDisplay } from '../utils/formatters';
+import { formatLocationSummary, formatPhase, getOverallStatusDisplay, groupStatuses } from '../utils/formatters';
 import { useDocumentTitle } from '../utils/useDocumentTitle';
 
 const PAGE_SIZE = 20;
@@ -36,12 +36,6 @@ const PHASE_OPTIONS = [
   { value: 'PHASE4', label: 'Phase 4' },
 ];
 
-const RECRUITING_STATUS_OPTIONS = [
-  { value: 'recruiting', label: 'Recruiting now' },
-  { value: 'not_recruiting', label: 'Not currently recruiting' },
-  { value: 'finished', label: 'Finished trials' },
-];
-
 const AGE_GROUP_OPTIONS = [
   { value: 'child', label: 'Child (Under 18)' },
   { value: 'adult', label: 'Adult (18–64)' },
@@ -51,11 +45,6 @@ const AGE_GROUP_OPTIONS = [
 const ADMIN_PHASE_OPTIONS = [
   { value: '', label: 'All phases' },
   ...PHASE_OPTIONS,
-];
-
-const ADMIN_RECRUITING_OPTIONS = [
-  { value: '', label: 'All statuses' },
-  ...RECRUITING_STATUS_OPTIONS,
 ];
 
 const SELECT_CLS = 'border border-line rounded-lg px-3 py-1.5 text-sm text-gray-700 bg-white shadow-sm cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-100 focus:border-brand-400 transition-colors hover:border-gray-300';
@@ -167,6 +156,148 @@ function FilterSection({ title, children }: { title: string; children: ReactNode
   );
 }
 
+function CheckboxOption({
+  checked,
+  indeterminate = false,
+  label,
+  count,
+  onChange,
+  className = '',
+}: {
+  checked: boolean;
+  indeterminate?: boolean;
+  label: string;
+  count?: number;
+  onChange: () => void;
+  className?: string;
+}) {
+  return (
+    <label className={`flex items-start gap-2 text-sm text-gray-700 cursor-pointer py-0.5 ${className}`}>
+      <input
+        type="checkbox"
+        checked={checked}
+        ref={(el) => {
+          // Indeterminate is a DOM property, not an attribute — React cannot set it via JSX.
+          if (el) el.indeterminate = indeterminate && !checked;
+        }}
+        onChange={onChange}
+        className="accent-brand-600 mt-0.5 shrink-0"
+      />
+      <span>
+        {label}
+        {count !== undefined && <span className="text-gray-400"> ({count})</span>}
+      </span>
+    </label>
+  );
+}
+
+/**
+ * Two-level recruitment-status filter: plain-English groups that expand to the
+ * individual ClinicalTrials.gov statuses inside them.
+ *
+ * Only statuses present in `statuses` (the facet, i.e. what the visible trials
+ * actually have) are offered, and anything outside a known group is listed as a
+ * standalone option — so no trial can be unreachable through this filter.
+ */
+function StatusFilter({
+  statuses,
+  selected,
+  onChange,
+}: {
+  statuses: StatusFacet[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const { groups, ungrouped } = groupStatuses(statuses.map((s) => s.value));
+  const countOf = (value: string) => statuses.find((s) => s.value === value)?.count ?? 0;
+
+  const selectedSet = new Set(selected);
+  const toggleStatus = (value: string) =>
+    onChange(
+      selectedSet.has(value)
+        ? selected.filter((s) => s !== value)
+        : [...selected, value],
+    );
+
+  function toggleGroup(members: string[]) {
+    const allOn = members.every((s) => selectedSet.has(s));
+    onChange(
+      allOn
+        ? selected.filter((s) => !members.includes(s))
+        : [...selected.filter((s) => !members.includes(s)), ...members],
+    );
+  }
+
+  function toggleExpanded(key: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  return (
+    <div className="space-y-1">
+      <CheckboxOption
+        checked={selected.length === 0}
+        label="All statuses"
+        onChange={() => onChange([])}
+      />
+      {groups.map((group) => {
+        const isOpen = expanded.has(group.key);
+        const groupCount = group.statuses.reduce((sum, s) => sum + countOf(s), 0);
+        return (
+          <div key={group.key}>
+            <div className="flex items-start gap-1">
+              <button
+                type="button"
+                onClick={() => toggleExpanded(group.key)}
+                aria-expanded={isOpen}
+                aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${group.label}`}
+                className="text-gray-400 hover:text-gray-600 mt-0.5 w-3 shrink-0 text-xs leading-5"
+              >
+                {isOpen ? '▾' : '▸'}
+              </button>
+              <CheckboxOption
+                checked={group.statuses.every((s) => selectedSet.has(s))}
+                indeterminate={group.statuses.some((s) => selectedSet.has(s))}
+                label={group.label}
+                count={groupCount}
+                onChange={() => toggleGroup(group.statuses)}
+              />
+            </div>
+            {isOpen && (
+              <div className="ml-4 pl-2 border-l border-line">
+                {group.statuses.map((status) => (
+                  <CheckboxOption
+                    key={status}
+                    checked={selectedSet.has(status)}
+                    label={getOverallStatusDisplay(status).label}
+                    count={countOf(status)}
+                    onChange={() => toggleStatus(status)}
+                    className="text-xs text-gray-600"
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+      {ungrouped.map((status) => (
+        <CheckboxOption
+          key={status}
+          checked={selectedSet.has(status)}
+          label={getOverallStatusDisplay(status).label}
+          count={countOf(status)}
+          onChange={() => toggleStatus(status)}
+        />
+      ))}
+    </div>
+  );
+}
+
 function RadioOption({
   name,
   value,
@@ -219,12 +350,13 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
   const [selectedIrrelevantId, setSelectedIrrelevantId] = useState<string | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Fetch facets once for filter dropdowns (public mode only)
+  // Fetch facets once for filter controls. Needed in both modes: the public
+  // sidebar and the admin status dropdown are both built from the statuses that
+  // actually exist. The endpoint is auth-aware, so admins get all trials'
+  // statuses while the public gets only approved ones.
   useEffect(() => {
-    if (!adminMode) {
-      getTrialFacets().then(setFacets).catch(console.error);
-    }
-  }, [adminMode]);
+    getTrialFacets().then(setFacets).catch(console.error);
+  }, []);
 
   // Fetch relevant trials whenever params change (always in public mode; relevant tab in admin)
   useEffect(() => {
@@ -270,6 +402,10 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
     setParams((p) => ({ ...p, q: undefined, page: 1 }));
     setIrrelevantParams((p) => ({ ...p, q: undefined, page: 1 }));
   }
+
+  const { groups: statusSelectGroups, ungrouped: statusSelectUngrouped } = groupStatuses(
+    facets?.statuses.map((s) => s.value) ?? [],
+  );
 
   const currentTotal = activeTab === 'irrelevant' ? irrelevantResponse?.total : response?.total;
   const totalPages = currentTotal !== undefined ? Math.ceil(currentTotal / PAGE_SIZE) : 1;
@@ -338,13 +474,25 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
               ))}
             </select>
           )}
-          {adminMode && activeTab === 'relevant' && (
+          {adminMode && activeTab === 'relevant' && facets && facets.statuses.length > 0 && (
             <select
               className={SELECT_CLS}
-              onChange={(e) => setFilter('recruiting_status', e.target.value)}
+              value={params.overall_status ?? ''}
+              onChange={(e) => setFilter('overall_status', e.target.value)}
             >
-              {ADMIN_RECRUITING_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
+              <option value="">All statuses</option>
+              {statusSelectGroups.map((group) => (
+                <optgroup key={group.key} label={group.label}>
+                  {/* Whole-group option first, then each status within it. Values are
+                      pipe-joined so they pass straight through to the API. */}
+                  <option value={group.statuses.join('|')}>All {group.label.toLowerCase()}</option>
+                  {group.statuses.map((s) => (
+                    <option key={s} value={s}>{getOverallStatusDisplay(s).label}</option>
+                  ))}
+                </optgroup>
+              ))}
+              {statusSelectUngrouped.map((s) => (
+                <option key={s} value={s}>{getOverallStatusDisplay(s).label}</option>
               ))}
             </select>
           )}
@@ -412,27 +560,17 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
 
             <div className="border-t border-line" />
 
-            <FilterSection title="Recruiting Status">
-              <div className="space-y-1">
-                <RadioOption
-                  name="recruiting_status"
-                  value=""
-                  checked={!params.recruiting_status}
-                  label="All statuses"
-                  onChange={() => setParams((p) => ({ ...p, recruiting_status: undefined, page: 1 }))}
+            {facets && facets.statuses.length > 0 && (
+              <FilterSection title="Recruiting Status">
+                <StatusFilter
+                  statuses={facets.statuses}
+                  selected={params.overall_status?.split('|').filter(Boolean) ?? []}
+                  onChange={(next) =>
+                    setParams((p) => ({ ...p, overall_status: next.join('|') || undefined, page: 1 }))
+                  }
                 />
-                {RECRUITING_STATUS_OPTIONS.map((o) => (
-                  <RadioOption
-                    key={o.value}
-                    name="recruiting_status"
-                    value={o.value}
-                    checked={params.recruiting_status === o.value}
-                    label={o.label}
-                    onChange={(v) => setParams((p) => ({ ...p, recruiting_status: v, page: 1 }))}
-                  />
-                ))}
-              </div>
-            </FilterSection>
+              </FilterSection>
+            )}
 
             <div className="border-t border-line" />
 
@@ -458,11 +596,11 @@ export function AllTrialsPage({ adminMode = false }: AllTrialsPageProps) {
               </div>
             </FilterSection>
 
-            {(params.phase || params.recruiting_status || params.age_group || params.country) && (
+            {(params.phase || params.overall_status || params.age_group || params.country) && (
               <>
                 <div className="border-t border-line" />
                 <button
-                  onClick={() => setParams((p) => ({ ...p, phase: undefined, recruiting_status: undefined, age_group: undefined, country: undefined, page: 1 }))}
+                  onClick={() => setParams((p) => ({ ...p, phase: undefined, overall_status: undefined, age_group: undefined, country: undefined, page: 1 }))}
                   className="text-xs font-medium text-brand-600 hover:text-brand-700 bg-brand-50 hover:bg-brand-100 px-2.5 py-1 rounded-full transition-colors"
                 >
                   Clear filters

--- a/frontend/src/pages/ReviewQueuePage.tsx
+++ b/frontend/src/pages/ReviewQueuePage.tsx
@@ -3,13 +3,9 @@ import { approveTrial, getReviewQueue, getTrial, rejectTrial } from '../api';
 import { IngestionEventBadge } from '../components/IngestionEventBadge';
 import { TrialDetailView } from '../components/TrialDetailView';
 import type { CustomEdits, TrialDetail, TrialListItem } from '../types';
+import { getOverallStatusDisplay, groupStatuses } from '../utils/formatters';
 import { useDocumentTitle } from '../utils/useDocumentTitle';
 
-const RECRUITING_NOW = ['RECRUITING'];
-const NOT_RECRUITING = ['NOT_YET_RECRUITING', 'ACTIVE_NOT_RECRUITING', 'ENROLLING_BY_INVITATION'];
-const FINISHED = ['COMPLETED', 'TERMINATED', 'WITHDRAWN', 'SUSPENDED'];
-
-type RecruitingFilter = '' | 'recruiting' | 'not_recruiting' | 'finished';
 type AiFilter = '' | 'confident' | 'unsure' | 'reject';
 
 export function ReviewQueuePage() {
@@ -19,7 +15,9 @@ export function ReviewQueuePage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<TrialDetail | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(false);
-  const [recruitingFilter, setRecruitingFilter] = useState<RecruitingFilter>('');
+  // Pipe-joined overall_status values, matching the GET /trials?overall_status syntax.
+  // Empty string means "all". Filtering is client-side over the already-loaded queue.
+  const [recruitingFilter, setRecruitingFilter] = useState<string>('');
   const [aiFilter, setAiFilter] = useState<AiFilter>('');
 
   useEffect(() => {
@@ -60,12 +58,15 @@ export function ReviewQueuePage() {
     };
   }, [selectedId]);
 
+  // Offer only the statuses the pending trials actually have, so the dropdown
+  // never lists an option that returns nothing.
+  const { groups: statusGroups, ungrouped: statusUngrouped } = groupStatuses(
+    [...new Set(queue.map((t) => t.overall_status).filter((s): s is string => !!s))],
+  );
+
   const filteredQueue = queue.filter((trial) => {
-    if (recruitingFilter) {
-      const status = trial.overall_status ?? '';
-      if (recruitingFilter === 'recruiting' && !RECRUITING_NOW.includes(status)) return false;
-      if (recruitingFilter === 'not_recruiting' && !NOT_RECRUITING.includes(status)) return false;
-      if (recruitingFilter === 'finished' && !FINISHED.includes(status)) return false;
+    if (recruitingFilter && !recruitingFilter.split('|').includes(trial.overall_status ?? '')) {
+      return false;
     }
     if (aiFilter && trial.ai_relevance_label !== aiFilter) return false;
     return true;
@@ -105,13 +106,21 @@ export function ReviewQueuePage() {
           <div className="mt-2 flex flex-col gap-1.5">
             <select
               value={recruitingFilter}
-              onChange={(e) => setRecruitingFilter(e.target.value as RecruitingFilter)}
+              onChange={(e) => setRecruitingFilter(e.target.value)}
               className="w-full text-xs border border-line rounded px-2 py-1 text-gray-600 bg-white focus:outline-none focus:ring-1 focus:ring-brand-400"
             >
               <option value="">All recruiting statuses</option>
-              <option value="recruiting">Recruiting</option>
-              <option value="not_recruiting">Not recruiting</option>
-              <option value="finished">Finished</option>
+              {statusGroups.map((group) => (
+                <optgroup key={group.key} label={group.label}>
+                  <option value={group.statuses.join('|')}>All {group.label.toLowerCase()}</option>
+                  {group.statuses.map((s) => (
+                    <option key={s} value={s}>{getOverallStatusDisplay(s).label}</option>
+                  ))}
+                </optgroup>
+              ))}
+              {statusUngrouped.map((s) => (
+                <option key={s} value={s}>{getOverallStatusDisplay(s).label}</option>
+              ))}
             </select>
             <select
               value={aiFilter}

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -31,6 +31,13 @@ const OVERALL_STATUS_MAP: Record<string, StatusDisplay> = {
   TERMINATED:                  { label: 'Terminated',                className: 'bg-red-100 text-red-800' },
   WITHDRAWN:                   { label: 'Withdrawn',                 className: 'bg-red-100 text-red-800' },
   UNKNOWN:                     { label: 'Unknown',                   className: 'bg-gray-100 text-gray-500' },
+  // Expanded-access statuses. Rarer than the interventional ones above, but they
+  // do occur in our search set and AGENT.md lists expanded access as eligible.
+  AVAILABLE:                   { label: 'Available',                 className: 'bg-green-100 text-green-800' },
+  TEMPORARILY_NOT_AVAILABLE:   { label: 'Temporarily not available',  className: 'bg-yellow-100 text-yellow-800' },
+  NO_LONGER_AVAILABLE:         { label: 'No longer available',        className: 'bg-gray-100 text-gray-600' },
+  APPROVED_FOR_MARKETING:      { label: 'Approved for marketing',     className: 'bg-gray-100 text-gray-600' },
+  WITHHELD:                    { label: 'Withheld',                   className: 'bg-gray-100 text-gray-500' },
 };
 
 /**
@@ -42,6 +49,79 @@ export function getOverallStatusDisplay(status: string | null | undefined): Stat
     label: status.replace(/_/g, ' ').toLowerCase().replace(/^\w/, (c) => c.toUpperCase()),
     className: 'bg-gray-100 text-gray-600',
   };
+}
+
+export interface StatusGroup {
+  /** Stable key for React lists and expand/collapse state. */
+  key: string;
+  label: string;
+  statuses: string[];
+}
+
+/**
+ * Plain-English groupings of ClinicalTrials.gov statuses, used to organise the
+ * recruiting-status filter into a two-level list.
+ *
+ * These are PRESENTATION ONLY. The API filters on individual `overall_status`
+ * values (see GET /trials?overall_status=A|B), so a group is just a preset that
+ * ticks its member statuses. Nothing is stored grouped, and a status missing
+ * from every group here still gets its own filter option — see
+ * groupStatuses(), which returns leftovers as `ungrouped`.
+ *
+ * Note the middle label: it deliberately names BOTH ends of the group. The
+ * previous wording, "Not currently recruiting", read as "closed" and hid the
+ * fact that not-yet-recruiting trials — which are still worth a referral —
+ * were inside it.
+ */
+export const STATUS_GROUPS: StatusGroup[] = [
+  {
+    key: 'recruiting',
+    label: 'Recruiting now',
+    statuses: ['RECRUITING', 'AVAILABLE'],
+  },
+  {
+    key: 'not_recruiting',
+    label: 'Not recruiting yet or no longer recruiting',
+    statuses: [
+      'NOT_YET_RECRUITING',
+      'ENROLLING_BY_INVITATION',
+      'ACTIVE_NOT_RECRUITING',
+      'TEMPORARILY_NOT_AVAILABLE',
+    ],
+  },
+  {
+    key: 'finished',
+    label: 'Finished trials',
+    statuses: [
+      'COMPLETED',
+      'TERMINATED',
+      'WITHDRAWN',
+      'SUSPENDED',
+      'NO_LONGER_AVAILABLE',
+      'APPROVED_FOR_MARKETING',
+    ],
+  },
+];
+
+/**
+ * Distributes the statuses actually present in the database across STATUS_GROUPS,
+ * dropping group members nothing has and collecting anything unrecognised.
+ *
+ * Callers render `groups` as parent/child options and `ungrouped` as standalone
+ * ones, which guarantees every status in `available` stays reachable — including
+ * values CT.gov may add after this code was written.
+ */
+export function groupStatuses(available: string[]): {
+  groups: StatusGroup[];
+  ungrouped: string[];
+} {
+  const present = new Set(available);
+  const groups = STATUS_GROUPS
+    .map((g) => ({ ...g, statuses: g.statuses.filter((s) => present.has(s)) }))
+    .filter((g) => g.statuses.length > 0);
+
+  const claimed = new Set(STATUS_GROUPS.flatMap((g) => g.statuses));
+  return { groups, ungrouped: available.filter((s) => !claimed.has(s)) };
 }
 
 /** Split a comma-joined location string into deduplicated trimmed parts. */

--- a/roadmap.md
+++ b/roadmap.md
@@ -46,7 +46,8 @@ Phases 1–3 complete; Phase 4 in progress. The ingestion pipeline is fully oper
 - **AI label display rename**: admin-facing UI now shows `Match` / `Partial Match` / `Not Suitable` instead of the underlying `confident` / `unsure` / `reject` values. The database, prompt, and API contract still use the original enum strings — display-only change in `AiClassificationCard`, `ReviewQueuePage`, and `LandingPage`.
 - **Brand palette and landing page redesign**: a named palette (`brand` blue `#2563a8`, `accent` olive, warm `surface` / `line` neutrals) replaces Tailwind's default blue across the whole front end, admin included. The landing page is rebuilt around a stat row and a static five-step timeline. Conventions are written up in [`docs/DESIGN.md`](docs/DESIGN.md), including the fact that `tailwind.config.js` changes need a dev-server restart. Semantic recruitment-status badges in `utils/formatters.ts` deliberately keep the default green/yellow/red/blue ramps.
 - **Site identity and metadata**: real favicon/app icons derived from the Osteosarcoma Now chain mark (blue on the logo green), plus `apple-touch-icon`, `site.webmanifest`, description, `theme-color`, and Open Graph / Twitter tags in `frontend/index.html`. Tab titles are per-route via `utils/useDocumentTitle.ts` — the Vite placeholders (`<title>frontend</title>`, `vite.svg`) are gone.
-- 68 tests passing (API, ingestion pipeline, AI services, UPDATED-trial guardrail)
+- **Recruitment status filtering rebuilt to be data-driven**: `GET /trials` now takes `overall_status=A|B` (pipe-separated raw CT.gov values, OR'd) instead of the three hardcoded `recruiting_status` buckets, and `GET /trials/facets` returns the statuses actually present with counts, auth-aware. Groupings survive as **presentation only** (`STATUS_GROUPS` in `formatters.ts`) — the public sidebar shows collapsible plain-English groups, admin dropdowns use `<optgroup>`. Fixes two real bugs: 104 of 848 trials (12%, mostly `UNKNOWN` plus expanded-access statuses) previously matched **no** filter option and were unreachable; and `NOT_YET_RECRUITING` trials were buried under a group labelled "Not currently recruiting", which read as closed and hid trials still worth a referral. See `docs/trial-status-filtering.md`.
+- 84 tests passing (API, ingestion pipeline, AI services, UPDATED-trial guardrail, status filtering + facets)
 - APScheduler running ingestion on configurable schedule (default 24 h)
 - Development environment (Docker/SQLite), Railway deployment, GitHub Actions CI
 
@@ -56,6 +57,7 @@ Phases 1–3 complete; Phase 4 in progress. The ingestion pipeline is fully oper
 - Phase 4: Role-based access (Admin vs. Reviewer) — can be stored as Clerk public metadata
 - Phase 5: `config.yaml` for search terms and schedule management
 - Phase 6: Verify WordPress PHP template integration end-to-end
+- Status filtering uses `overall_status` only, never `custom_overall_status`: an admin override changes the badge but not which filter the trial answers to (the countries facet does coalesce the two). See "Known gap" in `docs/trial-status-filtering.md`.
 - Design: the `accent-600` olive eyebrows sit at ~3:1 contrast on `surface`, below WCAG AA for small text. Darkening them to `accent-800` (`#607623`, 4.9:1) fixes it without changing the look much — a call for the brand owner, so left as specified for now.
 - Design: `og:image` / `og:url` in `frontend/index.html` are relative paths and need the deployed origin prefixed before social previews will render.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,6 +140,147 @@ async def test_get_trials_filters_by_status_pending_review_for_admin(test_client
 
 
 # ──────────────────────────────────────────────────────────
+# GET /trials?overall_status= (recruitment status filter)
+# ──────────────────────────────────────────────────────────
+
+async def _insert_approved(db_engine, *rows: tuple[str, str]):
+    """Insert (nct_id, overall_status) pairs as APPROVED trials."""
+    async with db_engine.begin() as conn:
+        for nct_id, overall_status in rows:
+            await conn.execute(
+                ClinicalTrial.__table__.insert().values(
+                    nct_id=nct_id,
+                    brief_title=f"Trial {nct_id}",
+                    overall_status=overall_status,
+                    status=TrialStatus.APPROVED,
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_trials_filters_by_single_overall_status(test_client, db_engine):
+    await _insert_approved(
+        db_engine,
+        ("NCT00000030", "RECRUITING"),
+        ("NCT00000031", "COMPLETED"),
+    )
+
+    r = await test_client.get("/api/v1/trials?overall_status=RECRUITING")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["items"][0]["nct_id"] == "NCT00000030"
+
+
+@pytest.mark.asyncio
+async def test_get_trials_pipe_separated_statuses_are_ored(test_client, db_engine):
+    """The case Katie hit: a clinician wants open AND about-to-open trials together."""
+    await _insert_approved(
+        db_engine,
+        ("NCT00000040", "RECRUITING"),
+        ("NCT00000041", "NOT_YET_RECRUITING"),
+        ("NCT00000042", "COMPLETED"),
+    )
+
+    r = await test_client.get("/api/v1/trials?overall_status=RECRUITING|NOT_YET_RECRUITING")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 2
+    assert {i["nct_id"] for i in body["items"]} == {"NCT00000040", "NCT00000041"}
+
+
+@pytest.mark.asyncio
+async def test_get_trials_overall_status_normalises_case_and_blanks(test_client, db_engine):
+    await _insert_approved(db_engine, ("NCT00000050", "RECRUITING"))
+
+    r = await test_client.get("/api/v1/trials?overall_status=recruiting| |")
+    assert r.status_code == 200
+    assert r.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_trials_status_outside_the_old_buckets_is_reachable(test_client, db_engine):
+    """
+    Regression: UNKNOWN and the expanded-access statuses belonged to none of the
+    three hardcoded buckets, so no filter option could ever return them.
+    """
+    await _insert_approved(
+        db_engine,
+        ("NCT00000060", "UNKNOWN"),
+        ("NCT00000061", "AVAILABLE"),
+        ("NCT00000062", "RECRUITING"),
+    )
+
+    r = await test_client.get("/api/v1/trials?overall_status=UNKNOWN|AVAILABLE")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 2
+    assert {i["nct_id"] for i in body["items"]} == {"NCT00000060", "NCT00000061"}
+
+
+# ──────────────────────────────────────────────────────────
+# GET /trials/facets (status facet)
+# ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_facets_returns_present_statuses_with_counts_in_display_order(
+    test_client, db_engine
+):
+    await _insert_approved(
+        db_engine,
+        ("NCT00000070", "COMPLETED"),
+        ("NCT00000071", "RECRUITING"),
+        ("NCT00000072", "RECRUITING"),
+    )
+
+    r = await test_client.get("/api/v1/trials/facets")
+    assert r.status_code == 200
+    statuses = r.json()["statuses"]
+
+    # RECRUITING sorts ahead of COMPLETED regardless of insertion order.
+    assert statuses == [
+        {"value": "RECRUITING", "count": 2},
+        {"value": "COMPLETED", "count": 1},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_facets_appends_unrecognised_statuses(test_client, db_engine):
+    """A status CT.gov adds later must still become a filter option."""
+    await _insert_approved(
+        db_engine,
+        ("NCT00000080", "RECRUITING"),
+        ("NCT00000081", "SOME_FUTURE_STATUS"),
+    )
+
+    r = await test_client.get("/api/v1/trials/facets")
+    values = [s["value"] for s in r.json()["statuses"]]
+    assert values == ["RECRUITING", "SOME_FUTURE_STATUS"]
+
+
+@pytest.mark.asyncio
+async def test_facets_hide_unapproved_statuses_from_anonymous_callers(test_client, db_engine):
+    await _insert_approved(db_engine, ("NCT00000090", "RECRUITING"))
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            ClinicalTrial.__table__.insert().values(
+                nct_id="NCT00000091",
+                brief_title="Pending Trial",
+                overall_status="WITHDRAWN",
+                status=TrialStatus.PENDING_REVIEW,
+            )
+        )
+
+    r = await test_client.get("/api/v1/trials/facets")
+    assert [s["value"] for s in r.json()["statuses"]] == ["RECRUITING"]
+
+    r = await test_client.get(
+        "/api/v1/trials/facets", headers={"Authorization": "Bearer test-token"}
+    )
+    assert [s["value"] for s in r.json()["statuses"]] == ["RECRUITING", "WITHDRAWN"]
+
+
+# ──────────────────────────────────────────────────────────
 # PATCH /trials/{nct_id} (backwards-compat endpoint)
 # ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What prompted this

A clinician asked to refer a patient to [NCT07630974](https://clinicaltrials.gov/study/NCT07630974) and reported it as missing from OSN. **It was approved and live.** The filter hid it.

The trial was `NOT_YET_RECRUITING`:

- **"Recruiting now"** excluded it.
- Its only other home was **"Not currently recruiting"** — which reads as *closed*, so there was no reason to look there when placing a referral.
- Its badge meanwhile read **"Not yet recruiting"**, a label appearing nowhere in the filter list.

One trial, described two different ways at the same moment, with the label that would have found it never shown. The reporter reasonably concluded ClinicalTrials.gov had renamed a status. They hadn't — `overall_status` genuinely changed from `NOT_YET_RECRUITING` to `RECRUITING` on 2026-07-06, and "Not currently recruiting" was never a CT.gov status. It was our own group label, inherited from the legacy WordPress template (`template-results.php:426`).

## Two structural faults

**1. Three hardcoded buckets covered only 8 of CT.gov's 14 statuses.** `UNKNOWN`, `AVAILABLE`, `NO_LONGER_AVAILABLE`, `TEMPORARILY_NOT_AVAILABLE`, `APPROVED_FOR_MARKETING` and `WITHHELD` belonged to none, so *every* filter option excluded them:

| Status | Count in our osteosarcoma search set |
|---|---|
| `UNKNOWN` | 97 |
| `NO_LONGER_AVAILABLE` | 3 |
| `AVAILABLE` | 2 |
| `APPROVED_FOR_MARKETING` | 1 |
| `TEMPORARILY_NOT_AVAILABLE` | 1 |
| **Total unreachable** | **104 of 848 (12%)** |

**2. The bucket lists were triplicated** across `endpoints.py`, `ReviewQueuePage.tsx` and the badge label map, with nothing keeping them in sync.

## The change

**The API filters on individual statuses. Groups exist only in the UI.**

- `GET /trials?overall_status=RECRUITING|NOT_YET_RECRUITING` — pipe-separated raw CT.gov values, OR'd, mirroring CT.gov's own filter syntax. Replaces `recruiting_status`, whose only consumer was this frontend (`/trail` doesn't accept it; no tests covered it).
- `GET /trials/facets` — returns statuses actually present, with counts, in lifecycle order. Unrecognised values are appended, so a status CT.gov adds later still becomes an option. Auth-aware like `GET /trials`, so an option never returns nothing.
- `STATUS_GROUPS` in `formatters.ts` is now the single definition of grouping. A group is a preset that ticks its members; `groupStatuses()` returns anything ungrouped as a standalone option — **this is what guarantees no trial can be unreachable.**
- The middle group is renamed **"Not recruiting yet or no longer recruiting"**, naming both ends of what it contains rather than implying closed.

### UI

Public sidebar — collapsible groups, multi-select, with counts:

```
[x] Recruiting now (12)
[-] Not recruiting yet or no longer recruiting (11)  v
      [x] Not yet recruiting (3)
      [ ] Active, not recruiting (7)
      [ ] Enrolling by invitation (1)
[ ] Finished trials (24)                             >
```

Admin dropdowns use native `<optgroup>` with an "All \<group\>" entry above each group's individual statuses.

## Verification

- **84 tests pass.** Adds 7 API tests — the filter and facets previously had **none** — including regressions for OR'd statuses and for statuses outside the old buckets.
- Smoke-tested end-to-end against a real DB: `RECRUITING|NOT_YET_RECRUITING` returns both (the reported case), `UNKNOWN|AVAILABLE` returns trials that no filter could previously reach, and facets correctly hide unapproved statuses from anonymous callers.
- Frontend typechecks and builds; no new lint errors (the 2 remaining exist on `main`).

## Notes for review

- **Migration-free** — no schema change. `overall_status` was already free-text.
- **Known gap, deliberate:** filtering uses `overall_status`, not `custom_overall_status`. An admin override changes the badge but not the filter. The countries facet does coalesce the two; scoped out to keep this contained. Logged in `roadmap.md` and the doc.
- Design rationale in `docs/trial-status-filtering.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
