### PR TITLE
Group UNKNOWN under the Finished trials filter

### DIFF
--- a/docs/trial-status-filtering.md
+++ b/docs/trial-status-filtering.md
@@ -72,6 +72,17 @@ a status missing from every group still gets its own checkbox.
 - **Admin dropdowns** (All Trials, Review Queue) — native `<optgroup>`s, with an
   "All \<group\>" entry above each group's individual statuses.
 
+### Where `UNKNOWN` sits
+
+`UNKNOWN` is grouped under **Finished trials**, on CT.gov's own definition: a
+study gets that status when its last known state was recruiting, not yet
+recruiting, or active-not-recruiting, it has passed its completion date, and
+nobody has verified it in two years. Their glossary is explicit — *"Studies
+with an unknown status are considered closed studies."*
+
+This matters more than it sounds: `UNKNOWN` is 97 of the 848 trials in our
+search set, by far the largest status that no filter could previously reach.
+
 ## Why groups are presentation-only
 
 Patients and families do not know CT.gov vocabulary; "Enrolling by invitation"

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -99,6 +99,12 @@ export const STATUS_GROUPS: StatusGroup[] = [
       'SUSPENDED',
       'NO_LONGER_AVAILABLE',
       'APPROVED_FOR_MARKETING',
+      // CT.gov's glossary is explicit: a study is UNKNOWN when its last known
+      // status was recruiting/not yet recruiting/active-not-recruiting, it has
+      // passed its completion date, and nobody has verified it in 2 years —
+      // "Studies with an unknown status are considered closed studies."
+      // https://clinicaltrials.gov/study-basics/glossary
+      'UNKNOWN',
     ],
   },
 ];


### PR DESCRIPTION
Follow-up to #74.

## What

Moves `UNKNOWN` into the **Finished trials** group.

## Why

ClinicalTrials.gov's glossary is explicit that these are closed studies. A record becomes `UNKNOWN` when:

- its last known status was recruiting, not yet recruiting, or active-not-recruiting, **and**
- it has passed its completion date, **and**
- nobody has verified it in the past two years.

> *"Studies with an unknown status are considered closed studies."*
> — [ClinicalTrials.gov glossary](https://clinicaltrials.gov/study-basics/glossary)

After #74, `UNKNOWN` belonged to no group, so `groupStatuses()` returned it as `ungrouped` and it rendered as a standalone checkbox below the three groups. Still reachable — that was the point of #74 — but it read as an anomaly rather than as what it is.

This matters more than it might sound: **`UNKNOWN` is 97 of the 848 trials** in our osteosarcoma search set, by far the largest status that no filter could reach before #74.

## Change

One entry added to `STATUS_GROUPS` in `frontend/src/utils/formatters.ts`, with the glossary rationale as a comment, plus a short section in `docs/trial-status-filtering.md` recording why it sits there.

No API, schema, or test changes — exactly the "adding or changing a group" path the doc describes, which is the design working as intended.

## Verification

84 tests pass; frontend typechecks and builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
