### PR TITLE
Hide feedback button while an admin is editing a trial

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { SignIn, useAuth } from '@clerk/clerk-react';
 import { Layout } from './components/Layout';
+import { EditModeProvider } from './context/EditModeContext';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { LandingPage } from './pages/LandingPage';
 import { AllTrialsPage } from './pages/AllTrialsPage';
@@ -30,6 +31,7 @@ function App() {
   }, [getToken]);
 
   return (
+    <EditModeProvider>
     <Routes>
       {/* Public routes */}
       <Route path="/" element={<Layout variant="public"><LandingPage /></Layout>} />
@@ -57,6 +59,7 @@ function App() {
 
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
+    </EditModeProvider>
   );
 }
 

--- a/frontend/src/components/FeedbackButton.tsx
+++ b/frontend/src/components/FeedbackButton.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
+import { useEditMode } from '../context/EditModeContext';
 
 const GOOGLE_FORM_URL =
   'https://docs.google.com/forms/d/e/1FAIpQLSeY3LQ8rE-uyddr96IefrzM92_DZBiW4VIEbDFul0jVyoQs7w/viewform';
 const GITHUB_ISSUES_URL = 'https://github.com/The-Bardo-Foundation/ONTEX/issues';
 
 export function FeedbackButton() {
+  const { isEditMode } = useEditMode();
   const [open, setOpen] = useState(false);
+
+  if (isEditMode) return null;
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/frontend/src/components/TrialDetailView.tsx
+++ b/frontend/src/components/TrialDetailView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { CustomEdits, TrialDetail } from '../types';
 import { formatLocationSummary, formatPhase, getOverallStatusDisplay, isLocationVerbose } from '../utils/formatters';
@@ -7,6 +7,7 @@ import { FieldDiffPanel } from './FieldDiffPanel';
 import { IngestionEventBadge } from './IngestionEventBadge';
 import { OfficialVsCustomPanel } from './OfficialVsCustomPanel';
 import { StatusBadge } from './StatusBadge';
+import { useEditMode } from '../context/EditModeContext';
 
 function InfoField({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -33,6 +34,12 @@ export function TrialDetailView({ trial, onApprove, onReject, onEdit, onMarkIrre
   const [editMode, setEditMode] = useState(false);
   const [markIrrelevantMode, setMarkIrrelevantMode] = useState(false);
   const [irrelevanceReason, setIrrelevanceReason] = useState('');
+
+  const { setIsEditMode } = useEditMode();
+  useEffect(() => {
+    setIsEditMode(editMode);
+    return () => setIsEditMode(false);
+  }, [editMode]);
 
   function handleFieldChange(field: keyof CustomEdits, value: string) {
     setEdits((prev) => ({ ...prev, [field]: value }));

--- a/frontend/src/context/EditModeContext.tsx
+++ b/frontend/src/context/EditModeContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+const EditModeContext = createContext<{
+  isEditMode: boolean;
+  setIsEditMode: (v: boolean) => void;
+}>({ isEditMode: false, setIsEditMode: () => {} });
+
+export function EditModeProvider({ children }: { children: ReactNode }) {
+  const [isEditMode, setIsEditMode] = useState(false);
+  return (
+    <EditModeContext.Provider value={{ isEditMode, setIsEditMode }}>
+      {children}
+    </EditModeContext.Provider>
+  );
+}
+
+export function useEditMode() {
+  return useContext(EditModeContext);
+}


### PR DESCRIPTION
## Summary
- Adds `EditModeContext` so `TrialDetailView` can broadcast when its edit mode is active
- `FeedbackButton` hides itself while edit mode is active so it doesn't float over the edit form

## Test plan
- [ ] In the admin trial detail view, enter edit mode and confirm the feedback button disappears while editing
- [ ] Exit edit mode and confirm the feedback button reappears