### PR TITLE
Collapse the mobile menu on any route change

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -19,6 +19,27 @@ export function Layout({
   const { isSignedIn } = useAuth();
   const { pathname } = useLocation();
 
+  /*
+   * Collapse the mobile menu on any route change.
+   *
+   * The menu links close the panel themselves, which covers tapping one for the
+   * route you are already on — that navigates nowhere, so this would not fire.
+   * This covers every other way the route can change while the panel is open:
+   * the logo, browser back/forward, a sign-in redirect. Without it the panel
+   * stays expanded over whatever screen you land on.
+   *
+   * Adjusting state during render rather than in an effect is deliberate — it
+   * is React's documented way to reset state when a value changes, and it is
+   * what `react-hooks/set-state-in-effect` (an error in this project) exists to
+   * push you towards. React re-runs this component immediately, before anything
+   * is painted, so the panel never appears on the new route.
+   */
+  const [menuPathname, setMenuPathname] = useState(pathname);
+  if (menuPathname !== pathname) {
+    setMenuPathname(pathname);
+    setMenuOpen(false);
+  }
+
   const adminNavLinkClass = ({ isActive }: { isActive: boolean }) =>
     `block px-3 py-2 rounded-md text-sm font-medium ${
       isActive ? 'bg-brand-50 text-brand-700' : 'text-gray-600 hover:bg-gray-100'


### PR DESCRIPTION
Addresses the Copilot review finding on #81. The finding is correct.

The mobile nav panel I added in #82 was only closed by the two links inside it. Any other route change left it expanded over the next screen — tapping the logo, browser back/forward, or the sign-in redirect. I chose the `onClick` handlers over a route-change reset at the time for simplicity, and undercounted the ways a route changes.

The links keep their own `onClick`. That is not redundant: tapping "Search Trials" while already on `/trials` navigates nowhere, so a route-change reset would not fire and the panel would stay open.

## Why this adjusts state during render

The obvious fix is:

```tsx
useEffect(() => { setMenuOpen(false); }, [pathname]);
```

That trips `react-hooks/set-state-in-effect`, which is an **error** in this project — I confirmed it against the local ESLint rather than assuming. Adjusting state during render is what that rule's own message points you towards, and React re-runs the component immediately, before painting, so the panel never flashes on the new route.

The alternative of deriving `menuOpen = menuOpenPath === pathname` was rejected: navigating back to the route where the menu was open would resurrect it.

`pathname` was already destructured for the feedback button, so this adds no new subscription.

## Verification

- `npx eslint src/components/Layout.tsx` — clean.
- `npm run build` (tsc + vite) — passes.

Not verified visually; there's no browser automation here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
